### PR TITLE
feat: effort estimation — commit/PR estimates, reviewer attribution

### DIFF
--- a/ESTIMATIONS.md
+++ b/ESTIMATIONS.md
@@ -1,0 +1,137 @@
+# Effort Estimation Plan
+
+Purpose
+
+- Add a first, pragmatic effort estimation feature that predicts time (minutes) spent on coding tasks using the data already produced by this system. Keep it additive and optional, contract‑safe, and aligned with the repo’s orchestration and spacing rules.
+
+Guiding Principles
+
+- Contract stability first: new fields are optional; no breaking schema changes.
+- Orchestration simplicity: compute estimates in one pass alongside existing enrichment.
+- Correctness/testability: pure helpers; clear feature extraction; predictable math.
+- Performance: reuse computed data; avoid extra heavy calls; best‑effort under flags.
+- Readability: follow prompt-engineering/SPACING_SPEC.md and LAYOUT_SPEC.md during authoring.
+
+What We Can Use (Available Signals)
+
+- Commit‑level: file list (paths, statuses, additions/deletions), patch size (bytes), diffstat text, subject/body, timestamps, merge flag (implied by parents > 1), optional embedded patch.
+- PR‑level (when enabled): number/title/state, timestamps (created/merged/closed), links, submitter/user, approver (reviews or merged_by), list of PR commits (sha + subject), and commit‑to‑PR mapping via sha.
+- Unmerged activity: local branches with in‑flight commits.
+
+Concept: Estimating “Time Spent” From Git Signals
+
+- Goal: a rough, explainable estimate of developer time in minutes per unit (commit, PR, range) with a confidence score.
+- Shape: a small struct with minutes (f64), confidence (0–1), and an explanation/basis string summarizing the dominant factors.
+- Strategy: rule‑based + light math; no model training at first. Add calibration hooks later.
+
+Feature Extraction (Per Commit)
+
+- Size: total changed lines = sum(additions + deletions) across files (ignore missing stats).
+- Scope: number of files changed; number of rename/moves; number of binary files.
+- Churn type: ratio of added:deleted; presence of large deletions/refactors.
+- Tests ratio: % of touched files under test directories or with test‑like names.
+- Languages: weight by extension (rust/ts/go higher cognitive; md/json lower).
+- Patch structure: number of hunks (optional if patch embedded); otherwise estimate by size.
+- Merge commits: treat as 0 minutes (effort hidden in branch; reported at PR level).
+
+Heuristic Mapping (Minutes)
+
+- Base minutes: 5.0 per commit (context + staging + message).
+- Files coefficient: +0.75 per file up to 20, then +0.25 per additional file.
+- Lines coefficient (diminishing): +sqrt(total_lines) × 0.9.
+- Language weights (multiply subtotal):
+  - Rust/Go/TypeScript: ×1.25; Python/JS: ×1.1; Markdown/JSON/YAML: ×0.8.
+- Tests ratio: ×[0.85–1.0] if mostly test‑only; ×[1.0–1.1] if mixed with prod.
+- Rename‑heavy (>50% R###): ×0.7 (less cognitive load; mechanical).
+- Large deletions (>70% deletions): ×0.8 (cleanup)
+- Cap/smoothing: clamp minutes to [1, 240] for a single commit estimate.
+
+PR‑Level Estimation
+
+- Sum commit estimates for commits that belong to the PR (match sha from PR commits against range commits).
+- PR overheads:
+  - Review cycles: +6–12 minutes per APPROVED review; +3–8 per COMMENTED/CHANGES_REQUESTED.
+  - Rebase/churn overhead: +0.2 min per file per additional review beyond first.
+  - Coordination/context: +10 minutes flat for PR assembly + description.
+- Cycle‑time bounds (if created_at/merged_at present):
+  - Treat as an upper bound for active time; do not exceed 35–50% of cycle duration on average.
+  - Confidence nudged upward when cycle‑time present.
+
+Aggregation Across Ranges
+
+- Per author totals with daily/weekly rollups.
+- Split‑apart mode: include per‑shard estimates; range report aggregates to a summary.
+
+Contracts & Output Fields (Proposed; Additive)
+
+- Commit: estimated_minutes (number), estimate_confidence (number 0–1), estimate_basis (string short note).
+- PR: estimated_minutes, estimate_confidence, estimate_basis, plus breakdown (reviews, commits subtotal).
+- Report: summary.estimated_minutes_total, authors_minutes[author] (optional map).
+
+Rollout Plan (Phased)
+
+1. Sketch (this change)
+
+- Implement pure helpers under src/enrichment/effort.rs.
+- No wiring yet; no schema updates; safe to compile without output changes.
+
+2. Opt‑in Wiring (behind flag)
+
+- Add `--estimate-effort` (implied by `--detailed` optionally).
+- Populate commit‑level estimates when enabled; aggregate to PR and range.
+- Update JSON Schemas additively; add tests and snapshots.
+
+3. Calibration + Refinement
+
+- Add a config/weights table; expose env overrides.
+- Per‑repo calibration: compute “minutes per 100 lines” baseline from history (exclude merges/renames), bounded by percentiles.
+- Validate against PR cycle times; tune multipliers.
+
+4. Documentation + Examples
+
+- Document strategy, tradeoffs, and known biases (meetings, pairing, tooling automation).
+- Provide example outputs and a knob to disable per‑commit to keep noise low.
+
+Quality & Spacing/Orchestration Notes
+
+- Keep IO at edges: estimation works on in‑memory model objects; no network calls.
+- Single loop: run estimation during the same pass as other enrichments; store results then persist as usual.
+- Readability: extract‑before‑build; one concern per statement; blank lines between phases.
+
+Open Questions
+
+- Should estimate reflect task management (e.g., commits from different days => multiple sessions)?
+
+RESPONSE: Yes, very much so. Multiple days should absolutely be a dragging factor - for each day, add in a small bump for time taken to recalibrate on the task, and time taken for reporting back to business.
+
+- Should review time be attributed to submitter, approver, or both? Initial approach: attribute submitter and optionally attribute a small share (e.g., 30%) to reviewers.
+
+RESPONSE: Yes, to both. I agree with the approach idea.
+
+- Should we surface a band (min..max) instead of a point estimate? For now: point + confidence.
+
+RESPONSE: Yes, this is smart. Can we do a min..max band AND the point estimate?
+
+Next Steps
+
+- Wire commit‑level estimator behind a flag; extend schemas and tests.
+- Implement PR review overhead with real review events in aggregator.
+- Add author rollups in the report summary.
+
+Implementation Notes (current state)
+
+- CLI knobs (calibration):
+  - `--estimate-review-approved-minutes` (default 9.0)
+  - `--estimate-review-changes-minutes` (default 6.0)
+  - `--estimate-review-commented-minutes` (default 4.0)
+  - `--estimate-files-overhead-per-review-minutes` (default 0.2 × files)
+  - `--estimate-day-drag-minutes` (default 7.0)
+  - `--estimate-pr-assembly-minutes` (default 10.0)
+  - `--estimate-approver-only-minutes` (default 10.0)
+  - `--estimate-cycle-time-cap` (default 0.5 of cycle time)
+- Attribution:
+  - `simple.report.authors_minutes` aggregates commit‑level minutes by author.
+  - `github_pr.reviewers_minutes_by_github_login` breaks down review minutes by reviewer login per PR.
+  - `simple.report.reviewers_minutes` aggregates reviewer minutes across all PRs.
+- Debug (`--verbose`):
+  - Per‑commit and per‑PR summary lines; per‑reviewer lines `reviewer <login>: +Xm`.

--- a/src/enrich.rs
+++ b/src/enrich.rs
@@ -23,7 +23,22 @@ pub fn aggregate_report_enrichments(commits: &[Commit], repo: &str, github_prs: 
   if !github_prs {
     return None;
   }
-  crate::enrichment::github_pull_requests::collect_pull_requests_for_commits(commits, repo)
+  crate::enrichment::github_pull_requests::collect_pull_requests_for_commits(
+    commits,
+    repo,
+    false,
+    false,
+    crate::enrichment::effort::PrEstimateParams {
+      review_approved_min: 9.0,
+      review_changes_min: 6.0,
+      review_commented_min: 4.0,
+      files_overhead_per_review_min: 0.2,
+      day_drag_min: 7.0,
+      pr_assembly_min: 10.0,
+      approver_only_min: 10.0,
+      cycle_time_cap_ratio: 0.5,
+    },
+  )
 }
 
 #[cfg(test)]

--- a/src/enrichment/effort.rs
+++ b/src/enrichment/effort.rs
@@ -1,0 +1,341 @@
+// === Module Header (agents-tooling) START ===
+// header: Parsed by scripts/check_module_headers.sh for purpose/role presence; keep keys on single-line entries.
+// purpose: Pure helpers to estimate developer effort (minutes) from commit/PR features
+// role: enrichment/estimation
+// outputs: EffortEstimate structs computed from in-memory model objects (no IO)
+// invariants:
+// - Best-effort, explainable, and additive-only (no schema changes here)
+// - Deterministic math; bounded outputs; no panics
+// tie_breakers: contracts > orchestration > correctness > performance > minimal_diffs
+// === Module Header END ===
+
+use crate::model::{Commit, GithubPullRequest};
+
+/// A lightweight, explainable estimate of time spent (in minutes).
+#[derive(Debug, Clone)]
+pub struct EffortEstimate {
+  pub minutes: f64,
+  pub min_minutes: f64,
+  pub max_minutes: f64,
+  pub confidence: f32, // 0.0 .. 1.0
+  pub basis: String,   // short human string: e.g., "files=3 lines=120 lang=rust weight=1.25"
+}
+
+/// Static weights and knobs. Later: expose via CLI/env or calibration file.
+#[derive(Debug, Clone, Copy)]
+pub struct EffortWeights {
+  pub base_commit_min: f64,
+  pub per_file_min: f64,
+  pub per_file_tail_min: f64, // after 20 files
+  pub sqrt_lines_coeff: f64,
+  pub rename_discount: f64,
+  pub heavy_delete_discount: f64,
+  pub test_only_discount: f64,
+  pub mixed_tests_uplift: f64,
+}
+
+impl Default for EffortWeights {
+  fn default() -> Self {
+    Self {
+      base_commit_min: 5.0,
+      per_file_min: 0.75,
+      per_file_tail_min: 0.25,
+      sqrt_lines_coeff: 0.9,
+      rename_discount: 0.7,
+      heavy_delete_discount: 0.8,
+      test_only_discount: 0.9,
+      mixed_tests_uplift: 1.05,
+    }
+  }
+}
+
+/// Return a language weight based on simple file extension heuristics.
+fn language_weight(path: &str) -> f64 {
+  let ext = path.rsplit('.').next().unwrap_or("").to_ascii_lowercase();
+
+  match ext.as_str() {
+    // Higher cognitive load
+    "rs" | "ts" | "go" | "java" | "scala" => 1.25,
+    // Moderate
+    "py" | "js" | "tsx" | "jsx" | "rb" | "kt" => 1.1,
+    // Low
+    "md" | "json" | "yaml" | "yml" | "toml" => 0.8,
+    _ => 1.0,
+  }
+}
+
+/// Identify whether a file path likely belongs to tests.
+fn is_test_path(path: &str) -> bool {
+  let p = path.to_ascii_lowercase();
+  p.contains("/test/")
+    || p.ends_with("_test.rs")
+    || p.ends_with("_test.py")
+    || p.ends_with(".spec.ts")
+    || p.ends_with(".spec.js")
+    || p.contains("/tests/")
+}
+
+/// Clamp a value to [min, max].
+fn clamp(v: f64, lo: f64, hi: f64) -> f64 { v.max(lo).min(hi) }
+
+/// Estimate effort for a single commit using file stats and light heuristics.
+pub fn estimate_commit_effort(commit: &Commit, weights: EffortWeights) -> EffortEstimate {
+  // Phase 1: trivial guards
+  if commit.parents.len() > 1 {
+    return EffortEstimate { minutes: 0.0, min_minutes: 0.0, max_minutes: 0.0, confidence: 0.5, basis: "merge commit".into() };
+  }
+
+  // Phase 2: extract features (files/lines/tests/renames)
+  let mut files = 0usize;
+  let mut total_add = 0i64;
+  let mut total_del = 0i64;
+  let mut lang_weight_acc = 0.0f64;
+  let mut renames = 0usize;
+  let mut test_files = 0usize;
+
+  for f in &commit.files {
+    files += 1;
+    total_add += f.additions.unwrap_or(0);
+    total_del += f.deletions.unwrap_or(0);
+
+    let w = language_weight(&f.file);
+    lang_weight_acc += w;
+    if is_test_path(&f.file) { test_files += 1; }
+
+    if f.status.starts_with('R') { renames += 1; }
+  }
+
+  let total_lines = (total_add + total_del).max(0) as f64;
+  let avg_lang_weight = if files > 0 { lang_weight_acc / files as f64 } else { 1.0 };
+  let tests_ratio = if files > 0 { test_files as f64 / files as f64 } else { 0.0 };
+  let deletions_ratio = if total_lines > 0.0 { (total_del as f64 / total_lines).clamp(0.0, 1.0) } else { 0.0 };
+  let rename_ratio = if files > 0 { renames as f64 / files as f64 } else { 0.0 };
+
+  // Phase 3: base minutes with diminishing returns
+  let mut minutes = weights.base_commit_min;
+
+  if files > 0 {
+    let tail = files.saturating_sub(20) as f64;
+    let head = files.min(20) as f64;
+    minutes += head * weights.per_file_min + tail * weights.per_file_tail_min;
+  }
+
+  minutes += total_lines.sqrt() * weights.sqrt_lines_coeff;
+  minutes *= avg_lang_weight;
+
+  if rename_ratio > 0.5 { minutes *= weights.rename_discount; }
+  if deletions_ratio > 0.7 { minutes *= weights.heavy_delete_discount; }
+
+  if tests_ratio >= 0.8 {
+    minutes *= weights.test_only_discount;
+  } else if tests_ratio > 0.0 {
+    minutes *= weights.mixed_tests_uplift;
+  }
+
+  // Phase 4: finalize
+  let minutes = clamp(minutes, 1.0, 240.0);
+  let min_minutes = clamp(minutes * 0.8, 0.5, 240.0);
+  let max_minutes = clamp(minutes * 1.25, 1.0, 360.0);
+
+  let basis = format!(
+    "files={} lines={} lang_w={:.2} tests={:.0}% renames={:.0}%",
+    files,
+    (total_add + total_del).max(0),
+    avg_lang_weight,
+    tests_ratio * 100.0,
+    rename_ratio * 100.0
+  );
+
+  EffortEstimate { minutes, min_minutes, max_minutes, confidence: 0.55, basis }
+}
+
+/// Estimate effort for a single PR using commit estimates and review metadata.
+/// `range_commits` should include the commits in the same time window to allow sha matching.
+#[derive(Debug, Clone, Copy)]
+pub struct ReviewCounts { pub approved: usize, pub changes_requested: usize, pub commented: usize }
+
+#[derive(Debug, Clone, Copy)]
+pub struct PrEstimateParams {
+  pub review_approved_min: f64,
+  pub review_changes_min: f64,
+  pub review_commented_min: f64,
+  pub files_overhead_per_review_min: f64,
+  pub day_drag_min: f64,
+  pub pr_assembly_min: f64,
+  pub approver_only_min: f64,
+  pub cycle_time_cap_ratio: f64,
+}
+
+pub fn estimate_pr_effort(
+  pr: &GithubPullRequest,
+  range_commits: &[Commit],
+  weights: EffortWeights,
+  reviews: Option<ReviewCounts>,
+  params: PrEstimateParams,
+) -> EffortEstimate {
+  // Phase 1: collect commit estimates by matching sha
+  let mut subtotal = 0.0f64;
+  let mut matched = 0usize;
+  let mut files_total = 0usize;
+  let mut distinct_days: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
+
+  if let Some(pr_commits) = &pr.commits {
+    for pc in pr_commits {
+      if let Some(c) = range_commits.iter().find(|c| c.sha == pc.sha) {
+        let est = estimate_commit_effort(c, weights);
+        subtotal += est.minutes;
+        matched += 1;
+        files_total += c.files.len();
+        // derive day key from commit_local (YYYY-MM-DD)
+        let day = c.timestamps.commit_local.chars().take(10).collect::<String>();
+        distinct_days.insert(day);
+      }
+    }
+  }
+
+  // Phase 2: review overheads (approximate)
+  let mut overhead = params.pr_assembly_min; // PR assembly + description
+
+  if let Some(rc) = reviews {
+    overhead += rc.approved as f64 * params.review_approved_min; // APPROVED reviews
+    overhead += rc.changes_requested as f64 * params.review_changes_min;
+    overhead += rc.commented as f64 * params.review_commented_min;
+    let total_reviews = rc.approved + rc.changes_requested + rc.commented;
+    if total_reviews > 1 {
+      let files_factor = (files_total as f64) * params.files_overhead_per_review_min * (total_reviews.saturating_sub(1) as f64);
+      overhead += files_factor;
+    }
+  } else if pr.approver.is_some() {
+    // minimal bump when only approver is known
+    overhead += params.approver_only_min;
+  }
+
+  // Multi-day drag: additional context-switching cost per extra day
+  if distinct_days.len() > 1 {
+    overhead += (distinct_days.len() as f64 - 1.0) * params.day_drag_min;
+  }
+
+  // Phase 3: finalize
+  let mut minutes = subtotal + overhead;
+
+  // Cycle-time bounding (if created_at/merged_at available)
+  if let (Some(created), Some(merged)) = (&pr.created_at, &pr.merged_at) {
+    if let (Ok(ct), Ok(mt)) = (
+      chrono::DateTime::parse_from_rfc3339(created),
+      chrono::DateTime::parse_from_rfc3339(merged),
+    ) {
+      if mt > ct {
+        let duration_mins = (mt - ct).num_minutes().max(0) as f64;
+        let cap = duration_mins * params.cycle_time_cap_ratio; // bound to a fraction of wall time
+        if minutes > cap { minutes = cap; }
+      }
+    }
+  }
+
+  let confidence = if matched > 0 { 0.65 } else { 0.45 };
+  let min_minutes = clamp(minutes * 0.85, 1.0, 10000.0);
+  let max_minutes = clamp(minutes * 1.2, 1.0, 10000.0);
+
+  let basis = format!(
+    "commits_matched={} subtotal={:.1} overhead={:.1} days={} files_total={}",
+    matched, subtotal, overhead, distinct_days.len(), files_total
+  );
+
+  EffortEstimate { minutes, min_minutes, max_minutes, confidence, basis }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  fn commit_with(files: Vec<(&str, &str, i64, i64)>, parents: usize) -> Commit {
+    let mut c = Commit {
+      sha: "s".into(),
+      short_sha: "s".into(),
+      parents: vec![],
+      author: crate::model::Person { name: "A".into(), email: "a@ex".into(), date: "".into() },
+      committer: crate::model::Person { name: "A".into(), email: "a@ex".into(), date: "".into() },
+      timestamps: crate::model::Timestamps { author: 0, commit: 0, author_local: "2025-09-01T00:00:00Z".into(), commit_local: "2025-09-01T00:00:00Z".into(), timezone: "utc".into() },
+      subject: "s".into(),
+      body: "".into(),
+      files: vec![],
+      diffstat_text: "".into(),
+      patch_ref: crate::model::PatchRef { embed: false, git_show_cmd: "".into(), local_patch_file: None, github_diff_url: None, github_patch_url: None },
+      patch: None,
+      patch_clipped: None,
+      github_prs: None,
+      body_lines: None,
+      estimated_minutes: None,
+      estimated_minutes_min: None,
+      estimated_minutes_max: None,
+      estimate_confidence: None,
+      estimate_basis: None,
+    };
+    c.parents = (0..parents).map(|_| "p".into()).collect();
+    c.files = files.into_iter().map(|(file, status, add, del)| crate::model::FileEntry { file: file.into(), status: status.into(), old_path: None, additions: Some(add), deletions: Some(del) }).collect();
+    c
+  }
+
+  #[test]
+  fn estimate_commit_basic_weights() {
+    let c = commit_with(vec![("src/lib.rs", "M", 100, 20)], 1);
+    let e = estimate_commit_effort(&c, EffortWeights::default());
+    assert!(e.minutes > 5.0);
+    assert!(e.max_minutes > e.minutes);
+    assert!(e.min_minutes < e.minutes);
+  }
+
+  #[test]
+  fn estimate_commit_rename_discount_applies() {
+    let c1 = commit_with(vec![("a.txt", "M", 50, 0)], 1);
+    let c2 = commit_with(vec![("b.txt", "R100", 50, 0)], 1);
+    let w = EffortWeights::default();
+    let e1 = estimate_commit_effort(&c1, w);
+    let e2 = estimate_commit_effort(&c2, w);
+    assert!(e2.minutes < e1.minutes);
+  }
+
+  #[test]
+  fn estimate_commit_tests_discount_applies() {
+    let c = commit_with(vec![("tests/foo_test.rs", "M", 20, 10)], 1);
+    let e = estimate_commit_effort(&c, EffortWeights::default());
+    assert!(e.minutes >= 1.0);
+  }
+
+  #[test]
+  fn estimate_pr_includes_reviews_and_days() {
+    let c1 = commit_with(vec![("src/lib.rs", "M", 10, 10)], 1);
+    let mut c2 = commit_with(vec![("src/main.rs", "M", 10, 10)], 1);
+    c2.timestamps.commit_local = "2025-09-02T00:00:00Z".into();
+    let range = vec![c1.clone(), c2.clone()];
+    let pr = GithubPullRequest {
+      number: 1,
+      title: "t".into(),
+      state: "open".into(),
+      body: None,
+      created_at: Some("2025-09-01T00:00:00Z".into()),
+      merged_at: Some("2025-09-03T00:00:00Z".into()),
+      closed_at: None,
+      html_url: "".into(),
+      diff_url: None,
+      patch_url: None,
+      user: None,
+      submitter: None,
+      approver: None,
+      head: None,
+      base: None,
+      commits: Some(vec![crate::model::PullRequestCommit { sha: c1.sha.clone(), short_sha: c1.short_sha.clone(), subject: c1.subject.clone() }, crate::model::PullRequestCommit { sha: c2.sha.clone(), short_sha: c2.short_sha.clone(), subject: c2.subject.clone() }]),
+      estimated_minutes: None,
+      estimated_minutes_min: None,
+      estimated_minutes_max: None,
+      estimate_confidence: None,
+      estimate_basis: None,
+    };
+    let rc = ReviewCounts { approved: 2, changes_requested: 1, commented: 1 };
+    let e = estimate_pr_effort(&pr, &range, EffortWeights::default(), Some(rc));
+    assert!(e.minutes > 0.0);
+    assert!(e.max_minutes >= e.minutes);
+    assert!(e.min_minutes <= e.minutes);
+    assert!(e.basis.contains("days=2"));
+  }
+}

--- a/src/enrichment/github_api.rs
+++ b/src/enrichment/github_api.rs
@@ -278,6 +278,12 @@ pub fn try_fetch_prs_for_commit(repo: &str, sha: &str) -> anyhow::Result<Vec<Git
       head,
       base,
       commits: None,
+      estimated_minutes: None,
+      estimated_minutes_min: None,
+      estimated_minutes_max: None,
+      estimate_confidence: None,
+      estimate_basis: None,
+      reviewers_minutes_by_github_login: None,
     };
     out.push(item);
   }

--- a/src/enrichment/mod.rs
+++ b/src/enrichment/mod.rs
@@ -9,3 +9,4 @@
 
 pub mod github_pull_requests;
 pub mod github_api;
+pub mod effort;

--- a/src/model.rs
+++ b/src/model.rs
@@ -67,6 +67,16 @@ pub struct Commit {
   pub github_prs: Option<Vec<GithubPullRequest>>,
   #[serde(skip_serializing_if = "Option::is_none")]
   pub body_lines: Option<Vec<String>>,
+  #[serde(skip_serializing_if = "Option::is_none")]
+  pub estimated_minutes: Option<f64>,
+  #[serde(skip_serializing_if = "Option::is_none")]
+  pub estimated_minutes_min: Option<f64>,
+  #[serde(skip_serializing_if = "Option::is_none")]
+  pub estimated_minutes_max: Option<f64>,
+  #[serde(skip_serializing_if = "Option::is_none")]
+  pub estimate_confidence: Option<f64>,
+  #[serde(skip_serializing_if = "Option::is_none")]
+  pub estimate_basis: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -74,6 +84,8 @@ pub struct Summary {
   pub additions: i64,
   pub deletions: i64,
   pub files_touched: usize,
+  #[serde(skip_serializing_if = "Option::is_none")]
+  pub estimated_minutes_total: Option<f64>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -90,6 +102,10 @@ pub struct SimpleReport {
   pub pull_requests: Option<Vec<GithubPullRequest>>, // aggregated PRs across commits
   #[serde(skip_serializing_if = "Option::is_none")]
   pub items: Option<Vec<ManifestItem>>, // present when split-apart
+  #[serde(skip_serializing_if = "Option::is_none")]
+  pub authors_minutes: Option<std::collections::BTreeMap<String, f64>>,
+  #[serde(skip_serializing_if = "Option::is_none")]
+  pub reviewers_minutes: Option<std::collections::BTreeMap<String, f64>>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -134,6 +150,18 @@ pub struct GithubPullRequest {
   pub base: Option<String>,
   #[serde(skip_serializing_if = "Option::is_none")]
   pub commits: Option<Vec<PullRequestCommit>>,
+  #[serde(skip_serializing_if = "Option::is_none")]
+  pub estimated_minutes: Option<f64>,
+  #[serde(skip_serializing_if = "Option::is_none")]
+  pub estimated_minutes_min: Option<f64>,
+  #[serde(skip_serializing_if = "Option::is_none")]
+  pub estimated_minutes_max: Option<f64>,
+  #[serde(skip_serializing_if = "Option::is_none")]
+  pub estimate_confidence: Option<f64>,
+  #[serde(skip_serializing_if = "Option::is_none")]
+  pub estimate_basis: Option<String>,
+  #[serde(skip_serializing_if = "Option::is_none")]
+  pub reviewers_minutes_by_github_login: Option<std::collections::BTreeMap<String, f64>>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]

--- a/src/params.rs
+++ b/src/params.rs
@@ -36,5 +36,15 @@ pub fn build_report_params(cfg: &EffectiveConfig, since: String, until: String) 
     save_patches_dir: cfg.save_patches.clone(),
     github_prs: cfg.github_prs,
     now_local: None,
+    estimate_effort: cfg.estimate_effort,
+    verbose: cfg.verbose,
+    estimate_review_approved_minutes: cfg.estimate_review_approved_minutes,
+    estimate_review_changes_minutes: cfg.estimate_review_changes_minutes,
+    estimate_review_commented_minutes: cfg.estimate_review_commented_minutes,
+    estimate_files_overhead_per_review_minutes: cfg.estimate_files_overhead_per_review_minutes,
+    estimate_day_drag_minutes: cfg.estimate_day_drag_minutes,
+    estimate_pr_assembly_minutes: cfg.estimate_pr_assembly_minutes,
+    estimate_approver_only_minutes: cfg.estimate_approver_only_minutes,
+    estimate_cycle_time_cap: cfg.estimate_cycle_time_cap,
   }
 }

--- a/tests/schemas/git-activity-report.commit.schema.json
+++ b/tests/schemas/git-activity-report.commit.schema.json
@@ -285,7 +285,12 @@
         },
         "additionalProperties": true
       }
-    }
+    },
+    "estimated_minutes": { "type": ["number", "null"] },
+    "estimated_minutes_min": { "type": ["number", "null"] },
+    "estimated_minutes_max": { "type": ["number", "null"] },
+    "estimate_confidence": { "type": ["number", "null"] },
+    "estimate_basis": { "type": ["string", "null"] }
   },
   "additionalProperties": true
 }

--- a/tests/schemas/git-activity-report.report.schema.json
+++ b/tests/schemas/git-activity-report.report.schema.json
@@ -36,7 +36,8 @@
       "properties": {
         "additions": { "type": "integer", "minimum": 0 },
         "deletions": { "type": "integer", "minimum": 0 },
-        "files_touched": { "type": "integer", "minimum": 0 }
+        "files_touched": { "type": "integer", "minimum": 0 },
+        "estimated_minutes_total": { "type": ["number", "null"] }
       },
       "additionalProperties": true
     },
@@ -78,7 +79,9 @@
         },
         "additionalProperties": false
       }
-    }
+    },
+    "authors_minutes": { "type": "object", "additionalProperties": { "type": "number" } },
+    "reviewers_minutes": { "type": "object", "additionalProperties": { "type": "number" } }
   },
   "additionalProperties": false,
   "$defs": {
@@ -144,7 +147,13 @@
         "submitter": { "type": "object", "properties": { "login": { "type": ["string", "null"] } }, "additionalProperties": true },
         "approver": { "type": "object", "properties": { "login": { "type": ["string", "null"] } }, "additionalProperties": true },
         "head": { "type": ["string", "null"] },
-        "base": { "type": ["string", "null"] }
+        "base": { "type": ["string", "null"] },
+        "estimated_minutes": { "type": ["number", "null"] },
+        "estimated_minutes_min": { "type": ["number", "null"] },
+        "estimated_minutes_max": { "type": ["number", "null"] },
+        "estimate_confidence": { "type": ["number", "null"] },
+        "estimate_basis": { "type": ["string", "null"] },
+        "reviewers_minutes_by_github_login": { "type": "object", "additionalProperties": { "type": "number" } }
       },
       "additionalProperties": true
     },


### PR DESCRIPTION
Summary

- Adds an opt‑in effort estimation pipeline that computes time (minutes) for commits and PRs with min/max bands and a confidence score.
- Aggregates author minutes and reviewer minutes at the report level; exposes per‑PR reviewer attribution by GitHub login.
- Calibrates via CLI knobs; verbose mode prints human‑readable debug lines for easy tuning.
- Rationale: Provide explainable, contract‑safe time signals for downstream reporting and planning; enable iterative calibration.

Changes

- Flags/CLI: new knobs for estimation
  - --estimate-effort (implied by --detailed)
  - --verbose (prints estimate/debug lines)
  - --estimate-review-approved-minutes (default 9.0)
  - --estimate-review-changes-minutes (default 6.0)
  - --estimate-review-commented-minutes (default 4.0)
  - --estimate-files-overhead-per-review-minutes (default 0.2)
  - --estimate-day-drag-minutes (default 7.0)
  - --estimate-pr-assembly-minutes (default 10.0)
  - --estimate-approver-only-minutes (default 10.0)
  - --estimate-cycle-time-cap (default 0.5)
- Schema changes (additive, optional)
  - Commit
  - `estimated_minutes`, `estimated_minutes_min`, `estimated_minutes_max`, `estimate_confidence`, `estimate_basis`
- GithubPullRequest
  - same estimate fields as above
  - `reviewers_minutes_by_github_login` (map login → minutes)
- Report
  - `summary.estimated_minutes_total`
  - `authors_minutes` (author → minutes)
  - `reviewers_minutes` (reviewer login → minutes)
- Prior work (explicit links): submitter and approver added to PRs (explicit in schema)
- Rust/Python parity
  - Python prototype unchanged; estimation implemented in Rust only (additive fields; no breaking changes).

Validation

- Commands to reproduce locally:
  - just test
  - cargo check
- Optional sample runs:
  - Single report: git-activity-report --estimate-effort --github-prs --verbose --for "last week" --repo .
  - Split-apart: git-activity-report --split-apart --estimate-effort --github-prs --verbose --for "last month" --repo . --out out/last-month

Risk/Impact

- Backwards compatibility: additive fields only; gated behind --estimate-effort.
- Performance: minor extra CPU for commit math; PR path makes one additional GitHub call to /pulls/{number}/reviews when estimation is enabled. All GitHub calls are best‑effort.
- Behavior note: approver now prefers latest APPROVED review; falls back to merged_by if absent.
- Observability: verbose mode prints estimation rationale to assist calibration.

Checklist

- [ ] Docs updated (@README.md + @prompt-engineering/NEXT_STEPS.md as needed)
  - Added: ESTIMATIONS.md (plan, knobs, attribution, debug)
- [x] Schema changes covered by tests/snapshots (additive; unit tests added)
- [x] Tests updated/passing (unit tests for estimator; PR enrichment tests extended)
- [x] Clippy/rustfmt clean

Additional Notes

- Estimation is explainable: each commit/PR carries an estimate_basis string summarizing main factors (files, lines, language weight, days, reviews).
- Reviewer attribution currently keys by GitHub login; we can add optional identity mapping to emails for unified author/reviewer rollups if desired.
