### PR TITLE
feat(estimation): opt‑in commit/PR time estimates

### DIFF
--- a/.agents/cycles/0012.plan-integrate-time-estimation-enrichment-feat-add-time-estimation-enrichment.2025-09-12T21-43-46.md
+++ b/.agents/cycles/0012.plan-integrate-time-estimation-enrichment-feat-add-time-estimation-enrichment.2025-09-12T21-43-46.md
@@ -1,0 +1,222 @@
+# Cycle 0012 — plan: integrate time estimation enrichment (feat/add-time-estimation-enrichment) (2025-09-12T21-43-46)
+
+
+Use this template before editing code. Keep it short and decisive. Save a copy as `$GITROOT/.agents/cycles/<idx>.<short-desc>.<timestamp>.md` to log each cycle.
+
+1) Summary
+
+- Problem/intent:
+  - Incorporate the time‑estimation enrichment from `feat/add-time-estimation-enrichment` safely on top of `main`. Due to heavy divergence (model/cli/render) and known merge conflicts, prefer a clean re‑implementation that preserves current contracts and layout rules.
+
+- Deliverables (code/docs/tests):
+  - New pure module: `src/enrichment/effort.rs` (commit/PR estimators).
+  - CLI flag: `--estimate-effort` (opt‑in; implied by `--detailed`).
+  - Additive optional fields on `Commit` and `GithubPullRequest`: `estimated_minutes`, `estimated_minutes_min`, `estimated_minutes_max`, `estimate_confidence`, `estimate_basis`.
+  - Wiring in `commit.rs` (commit estimate) and post‑loop PR pass.
+  - Unit + integration tests; schema updates to allow optional fields; docs/man refresh.
+
+- Scope (modules/files/areas):
+  - Add: `src/enrichment/effort.rs` (+ tests).
+  - Touch: `src/model.rs`, `src/cli.rs`, `src/commit.rs`, `src/enrichment/mod.rs`, and minimal `src/render.rs` for PR pass; `tests/schemas/*`, `tests/integration/*`, `README.md`, `docs/man`.
+
+2) Context & Constraints
+
+- Domain context (what system does):
+  - Export Git activity to JSON with optional enrichment; estimations are explainable best‑effort hints.
+
+- Primary consumers (humans/services):
+  - Report‑writer agents and humans consuming JSON/Markdown outputs.
+
+- External contracts (APIs/schemas/CLIs):
+  - JSON Schemas remain backward‑compatible; new fields are additive/optional. CLI coherence with `--detailed` maintained.
+
+3) State & Invariants
+
+- State variables (k: description):
+  - `estimate_enabled` (bool), `weights`/`params` (in‑mem defaults).
+
+- Derived state (computed once):
+  - `range_commits` vector for PR estimates across the window.
+
+- Invariants (pre/post, must always hold):
+  - Only additive schema changes; no breaking renames.
+  - Estimation is pure (no IO/network), deterministic, panic‑free.
+  - Author enforced spacing/layout; one blank between compute/IO/push.
+
+4) Inputs → Outputs (Contracts)
+
+- Inputs (flags, env, APIs, files):
+  - Flags: `--estimate-effort` (opt‑in). Hidden tuning knobs deferred.
+  - Env/APIs: none new; reuse existing GitHub enrichment data.
+
+- Outputs (files, API responses, console):
+  - Commit/PR objects gain optional estimation fields when enabled.
+
+- Naming/shape contracts (stable filenames/paths; schema versions; pointer shapes):
+  - Field names: `estimated_minutes`, `estimated_minutes_min`, `estimated_minutes_max`, `estimate_confidence`, `estimate_basis` (minutes as unit).
+
+5) Orchestration Plan (Phases)
+
+- Phase 1 — Normalize/build inputs:
+  - Parse CLI → `estimate_enabled` in config.
+
+- Phase 2 — Resolve/derive:
+  - Build `ReportParams` carrying `estimate_enabled`.
+
+- Phase 3 — Process units (loop): generate → save/persist → index
+  - Build `Commit`; if enabled, attach commit estimate.
+  - If GitHub enrichment present and enabled, compute PR estimates after loop using range commits.
+
+- Finalize — aggregate/manifest → emit/return
+  - No filename/manifest changes; totals deferred to future cycle.
+
+6) Module/Boundary Plan
+
+- Resolution/parser module(s): `src/cli.rs`.
+- Processing/orchestrator module(s): `src/commit.rs` (commit estimate), `src/render.rs` (PR pass).
+- Assembly/rendering module(s): unchanged.
+- Persistence/manifest module(s): unchanged.
+- Enrichment/integration module(s): `src/enrichment/effort.rs`; export in `src/enrichment/mod.rs`.
+- Utilities/helpers: none new.
+
+7) Side Effects & IO
+
+- Filesystem (paths, write strategy): none new.
+- Network/API calls (best-effort vs. required): none; uses in‑memory data.
+- Subprocess/system calls: none.
+- Concurrency decisions: unchanged; estimators are cheap.
+
+8) Testing & Validation
+
+- Unit tests (pure helpers): estimator math (rename/test discounts; reviews; multi‑day drag; cycle‑time cap).
+- Contract tests (schemas/pointers/naming): add optional fields to schemas.
+- Integration tests (end-to-end scenarios): CLI with `--estimate-effort --detailed` over fixture; assert fields exist and sane.
+- Manual checks (smoke/paths/outputs): `just run-simple`, `just man`.
+
+9) Risks & Trade-offs
+
+- Purity vs. performance: pure helpers; negligible overhead.
+- Stability vs. ergonomics: minimal CLI surface; defer knobs.
+- Backward compatibility/migration: additive, flag‑gated; schemas updated.
+
+10) Tie-Breakers (apply in this order)
+
+1. Contract stability (filenames/schemas/protocols)
+2. Orchestration simplicity (single loop, explicit state)
+3. Correctness/testability (pure helpers, invariants)
+4. Performance (avoid duplicate heavy work)
+5. Minimal diff/readability
+
+11) Observability & Rollback
+
+- Logs/metrics/counters: none; `estimate_basis` string offers explainability.
+- Pointer/evidence to outputs: fields appear only when flag set.
+- Rollback plan: revert wiring commit or simply stop populating fields; helpers remain for later use.
+
+12) Cycle Metadata
+
+- Cycle id:
+- Short description:
+- Timestamp (start/end):
+- Links (PR/issues):
+
+
+---
+Repo Overlay (autogenerated skeleton)
+
+States (define enumerated program states here):
+- [fill: e.g., single, multi, write, preview, split, monolithic]
+
+Modules → Roles (from file headers):
+- src/commit.rs: commit construction/enrichment — Construct per-commit objects; enrich with optional PR links; embed or save patches as configured
+- src/gitio.rs: git/io-helpers — Provide thin, robust wrappers around `git` CLI to retrieve commit metadata, diffs, stats, and branch info for report generation
+- src/util.rs: utilities/helpers — Utilities for paths, time formatting, spacing-safe helpers, and man page rendering
+- src/render.rs: assembly/render — Assemble per-range reports; when split_apart, write commit shards and per-range report, returning a pointer
+- src/enrich.rs: enrichment/coordinator — Coordinator to apply configured enrichments; keeps orchestration separate from enrichment implementations
+- src/manifest.rs: persistence/manifest — Build and write overall manifest for multi-range runs
+- src/main.rs: entrypoint/orchestrator — Entrypoint orchestrator; normalize → resolve ranges → process ranges; print final JSON or pointer
+- src/range_windows.rs: resolution/parser — Resolve time windows into labeled ranges; parse "now" overrides; helpers for natural language buckets
+- src/range_processor.rs: processing/orchestrator — Orchestrate per-range processing: generate report JSON and save artifacts; assemble overall manifest for multi-range runs
+- src/model.rs: model/types — Define the JSON model (commits, ranges, manifests, GitHub PRs) shared by rendering and enrichment
+- src/cli.rs: cli/normalization — Parse CLI flags and produce an EffectiveConfig with consistent defaults and implied flags
+- src/ext/mod.rs: module/aggregation — Group extension traits and helpers for third-party crates and std types under a single `ext` namespace
+- src/ext/serde_json.rs: extension/serde_json — Provide ergonomic nested JSON fetching via dotted paths and safe typed extraction for serde_json::Value
+- src/enrichment/github_api.rs: enrichment/github-api — Isolated GitHub API helpers used by enrichment (token discovery, REST calls)
+- src/enrichment/github_pull_requests.rs: enrichment/integration — Best-effort enrichment adding GitHub PR links and PR list to a commit
+- src/enrichment/mod.rs: enrichment/namespace — Namespace for enrichment features (GitHub PRs, etc.)
+
+Module Outputs (from file headers):
+- src/commit.rs → Commit structs with files/diffstat/patch_ref; optional patch text and saved patch files
+- src/gitio.rs → Parsed commit meta, numstat/name-status, shortstat, patch text; branch names and ahead/behind/merged signals
+- src/util.rs → Canonicalized paths, formatted timestamps, directories ensured, man page text
+- src/render.rs → SimpleReport JSON (non-split) or pointer {dir, file} (split)
+- src/enrich.rs → Mutates Commit (per-commit enrichments) and returns optional aggregated enrichments for reports
+- src/manifest.rs → manifest.json file written under base_dir
+- src/main.rs → Either full JSON to stdout, or a pointer {dir,file}/{dir,manifest} to stdout; files on disk when split/multi
+- src/range_windows.rs → Vec<LabeledRange> (chronological earliest→latest); parsed DateTime for now when requested
+- src/range_processor.rs → Files on disk (reports, shards), optional manifest.json; stdout pointer or JSON per state
+- src/model.rs → Serializable structs with stable field names and optional enrichment fields
+- src/cli.rs → EffectiveConfig with normalized paths and flags; multi_windows is initialized false (set later)
+- src/ext/mod.rs → Re-exported submodules providing utility traits and helpers (e.g., JsonFetch)
+- src/ext/serde_json.rs → JsonFetch trait and JsonFetched wrapper for typed extraction with defaults
+- src/enrichment/github_api.rs → JSON values and typed commit snapshots for PRs
+- src/enrichment/github_pull_requests.rs → Mutated commit.patch_ref (diff/patch URLs) and commit.github_prs
+- src/enrichment/mod.rs → Public submodules implementing specific enrichments
+
+Module Invariants (from file headers):
+- src/commit.rs
+  - clip_patch preserves UTF-8 boundaries; patch_clipped is accurate
+  - body_lines derived when body is non-empty
+  - enrichment is best-effort; absence of PRs leaves fields None
+- src/util.rs
+  - prepare_out_dir returns an existing directory (either provided or temp timestamped)
+  - clip_patch never splits UTF-8; indicates clipping accurately
+  - format_shard_name pattern is stable and locale-independent
+- src/render.rs
+  - run_simple returns fully in-memory report consistent with schema
+  - run_report returns pointer JSON when split; otherwise full report JSON; file names are stable
+  - shard filenames follow YYYY.MM.DD-HH.MM-<shortsha>.json
+- src/manifest.rs
+  - manifest contains ranges[] in chronological order of entries provided
+  - file paths in entries are relative to base_dir and point to report-<label>.json
+  - generated_at is serialized in %Y-%m-%dT%H:%M:%S (local)
+- src/main.rs
+  - when cfg.multi_windows == true, an overall manifest.json is written and a pointer with {dir, manifest} is printed
+  - when cfg.split_apart == true and cfg.multi_windows == false, a pointer {dir, file} is printed for the range report
+  - when cfg.split_apart == false and cfg.multi_windows == false, a full JSON report is printed to stdout or written to --out
+- src/range_windows.rs
+  - resolve_ranges returns at least one range; ForPhrase buckets are ordered earliest→latest
+  - month_bounds yields [start_of_month, start_of_next_month]
+  - parse_now accepts RFC3339 or naive %Y-%m-%dT%H:%M:%S and never panics
+- src/range_processor.rs
+  - base_dir is prepared when split_apart || multi_windows
+  - per-range report file name is report-<label>.json when written to disk
+  - multi_windows ⇒ manifest.json exists and pointer {dir, manifest} printed
+  - single split ⇒ pointer {dir, file} printed; single non-split ⇒ JSON printed or written to --out
+- src/cli.rs
+  - exactly one window selection is provided: --month | --for | (--since & --until)
+  - --detailed implies include_unmerged/include_patch/github_prs
+  - out semantics: file path when single non-split; directory when split or multi
+- src/enrichment/github_api.rs
+  - Never panic; return None/empty on failures (best-effort enrichment)
+  - Token discovery prefers GITHUB_TOKEN, then `gh auth token`
+  - Origin parser only recognizes GitHub remotes (https or ssh)
+- src/enrichment/github_pull_requests.rs
+  - On success, preserves existing commit fields; sets URLs if present in first PR; attaches PR list
+  - On failure, commit remains valid; fields untouched
+
+Acceptance (checklist to adapt):
+- [ ] Program state derived once and stored centrally
+- [ ] Outputs mapped to enumerated states
+- [ ] Names/shapes stable and test-covered
+- [ ] Orchestrator phases clear; IO at edges
+- [ ] Invariants defined and asserted
+- [ ] Errors include what/where
+- [ ] Observability: pointers/ids/paths logged/printed
+
+Cycle Metadata (prefilled)
+
+- Cycle id: 0012
+- Short description: plan: integrate time estimation enrichment (feat/add-time-estimation-enrichment)
+- Timestamp: 2025-09-12T21-43-46
+- File: .agents/cycles/0012.plan-integrate-time-estimation-enrichment-feat-add-time-estimation-enrichment.2025-09-12T21-43-46.md

--- a/.agents/repo_overlay.json
+++ b/.agents/repo_overlay.json
@@ -1,6 +1,6 @@
 {
 "repo": "/Users/james/Projects/git-activity-report/gar-rs",
-"generated_at": "2025-09-09T14-19-55",
+"generated_at": "2025-09-12T21-43-46",
 "modules": [
 {
 "file": "src/commit.rs",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      TZ: America/Chicago
     steps:
       - name: Checkout
         uses: actions/checkout@v5

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ node_modules/
 real-output
 scratch
 /prompt-engineering
+.secrets

--- a/ESTIMATIONS.md
+++ b/ESTIMATIONS.md
@@ -1,0 +1,43 @@
+# Effort Estimation (Additive, Optional)
+
+Purpose
+
+- Provide an explainable, best‑effort estimate of time spent (in minutes) for commits and PRs using only data already captured by the tool. Estimates are optional and gated by `--estimate-effort` (also implied by `--detailed`).
+
+What it computes
+
+- Commit: estimated_minutes (+ min/max band, confidence, and a short basis string summarizing dominant factors).
+- PR: sums commit estimates that belong to the PR, then adds review/coordination overhead and a small multi‑day drag; bounds by a fraction of the PR cycle time when available.
+
+Heuristic (v0)
+
+- Base: 5.0 minutes per commit.
+- Files: +0.75 min per file up to 20, then +0.25 per additional file.
+- Lines: +sqrt(additions + deletions) × 0.9.
+- Language weighting: Rust/Go/TS ×1.25; Python/JS ×1.1; Markdown/JSON/YAML ×0.8.
+- Discounts: rename‑heavy (>50% R###) ×0.7; heavy deletions (>70%) ×0.8.
+- Tests: mostly tests (≥80%) ×0.9; mixed tests ×1.05.
+- PR overheads: APPROVED +9m; CHANGES_REQUESTED +6m; COMMENTED +4m; extra reviews add +0.2m × files; PR assembly +10m; approver only +10m.
+- PR cycle‑time cap: ≤ 50% of wall‑clock from created_at → merged_at when both known.
+
+Contracts
+
+- JSON fields are additive and optional:
+  - Commit: `estimated_minutes`, `estimated_minutes_min`, `estimated_minutes_max`, `estimate_confidence`, `estimate_basis`.
+  - PR: same fields attached to each PR object under `commit.github.pull_requests[]`.
+- Units are minutes (floating point). Downstream can present hours if desired.
+
+Usage
+
+```bash
+git activity-report --for "last week" --repo . --estimate-effort > out.json
+# or:
+git activity-report --detailed --for "last week" --repo . > out.json
+```
+
+Caveats
+
+- Estimates do not include meetings, pairing, deployment toil, or context outside commits/reviews.
+- Merge commits show 0 minutes; effort is attributed to the PR and constituent commits.
+- Confidence is indicative only; treat results as planning/communication aids, not timesheets.
+

--- a/README.md
+++ b/README.md
@@ -73,6 +73,36 @@ git activity-report --split-apart --for "last month" \
   --save-patches out/last-month/patches
 ```
 
+## Reading Estimates (optional)
+
+When you pass `--estimate-effort` (or `--detailed`), the tool attaches transparent time estimates (in minutes) to commits and PRs.
+
+- Commit fields (optional):
+  - `estimated_minutes`, `estimated_minutes_min`, `estimated_minutes_max`
+  - `estimate_confidence` (0–1) and `estimate_basis` (short explanation: files/lines/lang/tests/renames)
+
+- PR fields (optional; require `--github-prs`):
+  - Same five fields on each `github.pull_requests[]` entry. Basis summarizes matched commits + review overheads.
+
+Examples:
+
+```bash
+# Commit-level estimates for the first commit
+git activity-report --for "last week" --repo . --estimate-effort \
+  | jq '.commits[0] | {estimated_minutes,estimated_minutes_min,estimated_minutes_max,estimate_confidence,estimate_basis}'
+
+# PR-level estimates (requires GitHub auth or GITHUB_TOKEN)
+git activity-report --for "last week" --repo . --github-prs --estimate-effort \
+  | jq '.commits[] | select(.github!=null) | .github.pull_requests[] \
+        | {number,title,estimated_minutes,estimate_basis}'
+```
+
+Notes:
+
+- Units are minutes; downstream tools can format hours if desired.
+- Merge commits estimate to 0 minutes; effort is attributed to the PR and constituent commits.
+- Confidence is indicative only; the basis string explains the drivers.
+
 ## CLI reference (high‑use flags)
 
 - Time range (pick one):

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Export Git activity into structured JSON — either a single report or a split�
   - Split‑apart (`--split-apart`): per‑commit shard files plus a per‑range report (`report-<label>.json` with `items[]`), and an overall `manifest.json` for multi‑range runs.
 
 - **Optional GitHub PR enrichment**: attaches PR metadata and `.diff`/`.patch` links when available (quietly skipped if unauthenticated).
+- **Optional effort estimation**: with `--estimate-effort` (or `--detailed`), attaches transparent time estimates (minutes) to commits and PRs.
 - **Optional unmerged branch scan**: include commits in the window that are **not** reachable from `HEAD` (in‑flight work), grouped by local branch.
 - **Patches**: embed in JSON (`--include-patch`, optional `--max-patch-bytes`), and/or write `.patch` files to disk (`--save-patches`).
   Prototype: a Python script still lives under `prototype/` for reference, but the Rust binary is the primary implementation.
@@ -93,6 +94,7 @@ git activity-report --split-apart --for "last month" \
   - `--out`: for single report, a file path (default stdout "-"); for split‑apart or multi‑range, a base directory (default: auto‑named temp dir)
 
 - Integrations: `--github-prs`
+- Effort: `--estimate-effort` (adds `estimated_minutes*` fields to commits/PRs)
 - Unmerged work: `--include-unmerged`
 - Timezone label: `--tz local|utc` (default `local`)
 

--- a/docs/ESTIMATE_TUNING.md
+++ b/docs/ESTIMATE_TUNING.md
@@ -1,0 +1,130 @@
+# Exploring and Tuning Effort Estimates
+
+This guide shows how to explore, critique, and tune the effort estimation heuristics when numbers feel too optimistic (too low) or too pessimistic. The estimators are explainable and designed to be easy to calibrate.
+
+## What’s tunable today
+
+Two sets of weights drive estimates (see `src/enrichment/effort.rs`).
+
+- Commit weights (per‑commit):
+  - `base_commit_min` (default 5.0)
+  - `per_file_min` (0.75)
+  - `per_file_tail_min` (0.25; applies after 20 files)
+  - `sqrt_lines_coeff` (0.9; minutes added as `sqrt(add+del) * coeff`)
+  - Discounts/uplifts: `rename_discount` (0.7), `heavy_delete_discount` (0.8),
+    `test_only_discount` (0.9), `mixed_tests_uplift` (1.05)
+
+- PR weights (per‑PR; add overhead to commit subtotal):
+  - `pr_assembly_min` (10.0)
+  - `review_approved_min` (9.0), `review_changes_min` (6.0), `review_commented_min` (4.0)
+  - `files_overhead_per_review_min` (0.2 × files × extra_reviews)
+  - `day_drag_min` (7.0 per extra day the PR spans across its commits)
+  - `cycle_time_cap_ratio` (0.5; cap = 50% of wall‑clock `created_at → merged_at`)
+
+Currently, these weights are compiled constants; CLI flags for them are intentionally not exposed to keep the main surface small. The simple workflow below lets you iterate quickly and safely.
+
+## Workflow: measure → tweak → compare
+
+1) Produce a baseline
+
+```bash
+# Last week, UTC, stable "now" for reproducibility
+cargo run -- --for "last week" --repo . --estimate-effort --tz utc   --now-override 2025-09-15T12:00:00 > out-baseline.json
+
+# With PRs (token or gh auth required)
+cargo run -- --for "last week" --repo . --github-prs --estimate-effort --tz utc   --now-override 2025-09-15T12:00:00 > out-pr-baseline.json
+```
+
+2) Inspect totals and distributions
+
+```bash
+# Commit totals
+jq '[.commits[].estimated_minutes // 0] | {total: add, mean: (add/length)}' out-baseline.json
+
+# p50/p90 minutes per commit
+jq '[.commits[].estimated_minutes // 0] | sort | {p50: .[length*0.5|floor], p90: .[length*0.9|floor]}' out-baseline.json
+
+# PR totals (when github_prs is on)
+jq '[.commits[] | select(.github!=null) | .github.pull_requests[] | .estimated_minutes // 0]    | {total: add, mean: (add/length)}' out-pr-baseline.json
+
+# PR cycle‑time vs. estimate (sanity): ratio <= cap (default 0.5)
+jq -r '.commits[] | select(.github!=null) | .github.pull_requests[]   | select(.time_to_merge_seconds!=null)   | {n: .number, minutes: .estimated_minutes, wall_mins: (.time_to_merge_seconds/60)}' out-pr-baseline.json
+```
+
+3) Tweak weights (local patch) and rebuild
+
+Edit `src/enrichment/effort.rs` to change the defaults under `EffortWeights` and `PrEstimateParams` (both have `impl Default` blocks). Rebuild and re-run the same windows.
+
+Common adjustments when estimates feel low (optimistic):
+
+- Commit‑level
+  - Increase `base_commit_min` from 5 → 8–12.
+  - Increase `per_file_min` from 0.75 → 1.0–1.5.
+  - Increase `sqrt_lines_coeff` from 0.9 → 1.1–1.3.
+  - Soften discounts (closer to 1.0): `rename_discount` 0.7 → 0.9, `heavy_delete_discount` 0.8 → 0.95.
+  - Reduce test discount: `test_only_discount` 0.9 → 1.0; raise `mixed_tests_uplift` 1.05 → 1.15.
+
+- PR‑level
+  - Increase `pr_assembly_min` from 10 → 15–20.
+  - Increase review minutes: APPROVED 9 → 12, CHANGES_REQUESTED 6 → 10, COMMENTED 4 → 6.
+  - Increase `files_overhead_per_review_min` 0.2 → 0.4–0.6.
+  - Increase `day_drag_min` 7 → 10–12.
+  - If estimates get clipped too low by wall‑time bounds, increase `cycle_time_cap_ratio` 0.5 → 0.7.
+
+Rebuild and compare with your baseline outputs.
+
+```bash
+cargo build
+cargo run -- --for "last week" --repo . --estimate-effort --tz utc   --now-override 2025-09-15T12:00:00 > out-tuned.json
+
+jq '{base: ([.commits[].estimated_minutes // 0] | add), 
+     tuned: (input | [.commits[].estimated_minutes // 0] | add)}'   out-baseline.json out-tuned.json
+```
+
+4) Validate PRs match expectations
+
+If PR estimates still look low despite matched commits:
+
+- Confirm the window includes the PR’s commits (basis shows `commits_matched=N`). Choose a wider `--for` or `--since/--until` so matched commits reflect the PR contents.
+- Raise `pr_assembly_min`, review minutes, and `day_drag_min` as needed.
+- Consider increasing `cycle_time_cap_ratio` if your organization’s “active time” tends to be a larger fraction of wall time.
+
+## Presets to try
+
+- “Moderate” (more realistic for many teams)
+  - Commits: base 10.0, per_file 1.25, tail 0.4, sqrt_coeff 1.2, rename 0.9, del 0.95, test_only 1.0, mixed 1.15
+  - PRs: assembly 18, approved 12, changes 10, commented 6, files_overhead 0.5, day_drag 12, cap 0.7
+
+- “Conservative” (upper‑bound planning)
+  - Commits: base 12.0, per_file 1.5, tail 0.5, sqrt_coeff 1.3, rename 0.95, del 1.0, test_only 1.05, mixed 1.2
+  - PRs: assembly 25, approved 15, changes 12, commented 8, files_overhead 0.7, day_drag 15, cap 0.8
+
+## Optional: add runtime overrides (future work)
+
+If you want to explore without rebuilding, we can add either:
+
+- CLI flags for weights (hidden or advanced), or
+- Environment overrides (e.g., `GAR_EST_BASE_COMMIT_MIN=10`).
+
+This keeps JSON contracts stable (estimates remain optional fields) and makes calibration easier across repos. If you want, I can wire a minimal env‑override seam behind a feature flag in a follow‑up PR.
+
+## Tips & gotchas
+
+- Estimates are minutes; downstream can format hours.
+- Merge commits are treated as 0 (effort is attributed to the PR/branch work).
+- “Optimistic” outputs often mean: small `base_commit_min`, too‑low `sqrt_lines_coeff`, minimal PR overheads, or `cycle_time_cap_ratio` capping too hard.
+- Use `--now-override` and `--tz` to make runs reproducible across machines.
+
+## Appendix: quick jq snippets
+
+- Top 10 heaviest commits by estimated minutes
+
+```bash
+jq '.commits | sort_by(.estimated_minutes // 0) | reverse | .[:10]    | map({sha: .short_sha, subject, minutes: .estimated_minutes, basis: .estimate_basis})' out-tuned.json
+```
+
+- PRs with estimates and review counts
+
+```bash
+jq '.commits[] | select(.github!=null) | .github.pull_requests[]   | {n: .number, title: .title, minutes: .estimated_minutes,      reviews: .review_count, approvals: .approval_count, basis: .estimate_basis}' out-pr-baseline.json
+```

--- a/docs/ESTIMATE_TUNING.md
+++ b/docs/ESTIMATE_TUNING.md
@@ -106,13 +106,41 @@ If PR estimates still look low despite matched commits:
   - PRs: assembly 25, approved 15, changes 12, commented 8, files_overhead 0.7, day_drag 15, cap 0.8
 
 ## Optional: add runtime overrides (future work)
+Runtime overrides are available via environment variables (no rebuild):
 
-If you want to explore without rebuilding, we can add either:
+```
+# Commit weights
+export GAR_EST_BASE_COMMIT_MIN=10
+export GAR_EST_PER_FILE_MIN=1.25
+export GAR_EST_PER_FILE_TAIL_MIN=0.4
+export GAR_EST_SQRT_LINES_COEFF=1.2
+export GAR_EST_RENAME_DISCOUNT=0.9
+export GAR_EST_HEAVY_DELETE_DISCOUNT=0.95
+export GAR_EST_TEST_ONLY_DISCOUNT=1.0
+export GAR_EST_MIXED_TESTS_UPLIFT=1.15
+export GAR_EST_COG_BASE_MIN=12
+export GAR_EST_COG_EXT_MIX_COEFF=0.4
+export GAR_EST_COG_DIR_MIX_COEFF=0.4
+export GAR_EST_COG_BALANCED_EDIT_COEFF=0.1
+export GAR_EST_COG_LANG_COMPLEXITY_COEFF=0.1
 
-- CLI flags for weights (hidden or advanced), or
-- Environment overrides (e.g., `GAR_EST_BASE_COMMIT_MIN=10`).
+# PR overheads
+export GAR_EST_PR_REVIEW_APPROVED_MIN=12
+export GAR_EST_PR_REVIEW_CHANGES_MIN=10
+export GAR_EST_PR_REVIEW_COMMENTED_MIN=6
+export GAR_EST_PR_FILES_OVERHEAD_PER_REVIEW_MIN=0.5
+export GAR_EST_PR_DAY_DRAG_MIN=12
+export GAR_EST_PR_ASSEMBLY_MIN=18
+export GAR_EST_PR_APPROVER_ONLY_MIN=12
+export GAR_EST_PR_CYCLE_TIME_CAP_RATIO=0.7
+```
 
-This keeps JSON contracts stable (estimates remain optional fields) and makes calibration easier across repos. If you want, I can wire a minimal env‑override seam behind a feature flag in a follow‑up PR.
+Unset to return to defaults:
+
+```
+env -u GAR_EST_BASE_COMMIT_MIN -u GAR_EST_PER_FILE_MIN \
+  -u GAR_EST_PR_ASSEMBLY_MIN -- cargo run -- …
+```
 
 ## Tips & gotchas
 

--- a/docs/TUNING_DISCOVERY.md
+++ b/docs/TUNING_DISCOVERY.md
@@ -1,0 +1,75 @@
+# Estimation Tuning Discovery — A/B Snapshot
+
+Context
+
+- Window: last week (relative to a fixed now)
+- Now (override): 2025-09-15T12:00:00 (UTC)
+- Repo: this repository
+- Goal: compare baseline estimator vs. a more conservative profile to better account for cognitive overhead and PR process time.
+
+Reproduction
+
+- Baseline (no env overrides):
+
+```
+cargo run -- --for "last week" --repo . --estimate-effort --tz utc   --now-override 2025-09-15T12:00:00 > out-baseline.json
+
+# With PRs (requires token or gh auth)
+cargo run -- --for "last week" --repo . --github-prs --estimate-effort --tz utc   --now-override 2025-09-15T12:00:00 > out-pr-baseline.json
+```
+
+- Conservative profile (set in shell, no rebuild required):
+
+```
+# Commit weights
+export GAR_EST_BASE_COMMIT_MIN=12
+export GAR_EST_PER_FILE_MIN=1.5
+export GAR_EST_PER_FILE_TAIL_MIN=0.5
+export GAR_EST_SQRT_LINES_COEFF=1.3
+export GAR_EST_RENAME_DISCOUNT=0.95
+export GAR_EST_HEAVY_DELETE_DISCOUNT=1.0
+export GAR_EST_TEST_ONLY_DISCOUNT=1.05
+export GAR_EST_MIXED_TESTS_UPLIFT=1.2
+export GAR_EST_COG_BASE_MIN=12
+export GAR_EST_COG_EXT_MIX_COEFF=0.4
+export GAR_EST_COG_DIR_MIX_COEFF=0.4
+export GAR_EST_COG_BALANCED_EDIT_COEFF=0.1
+export GAR_EST_COG_LANG_COMPLEXITY_COEFF=0.1
+
+# PR overheads
+export GAR_EST_PR_REVIEW_APPROVED_MIN=15
+export GAR_EST_PR_REVIEW_CHANGES_MIN=12
+export GAR_EST_PR_REVIEW_COMMENTED_MIN=8
+export GAR_EST_PR_FILES_OVERHEAD_PER_REVIEW_MIN=0.7
+export GAR_EST_PR_DAY_DRAG_MIN=15
+export GAR_EST_PR_ASSEMBLY_MIN=25
+export GAR_EST_PR_APPROVER_ONLY_MIN=12
+export GAR_EST_PR_CYCLE_TIME_CAP_RATIO=0.8
+
+cargo run -- --for "last week" --repo . --estimate-effort --tz utc   --now-override 2025-09-15T12:00:00 > out-tuned.json
+
+# With PRs
+cargo run -- --for "last week" --repo . --github-prs --estimate-effort --tz utc   --now-override 2025-09-15T12:00:00 > out-pr-tuned.json
+```
+
+Results
+
+- Commit estimates (from this repo, UTC, last week):
+  - Baseline: count=18, total≈419.64, mean≈23.31, min≈9.24, max≈56.07
+  - Conservative: count=18, total≈726.96, mean≈40.39, min≈17.70, max≈95.06
+  - Delta: mean +≈73% (23.31 → 40.39)
+
+- PR estimates (deduped by PR number):
+  - Baseline: count=2, total≈192.39, mean≈96.20, min=3.0, max≈189.39
+  - Conservative: count=2, total≈347.52, mean≈173.76, min≈4.80, max≈342.72
+  - Delta: mean +≈80%
+
+Interpretation
+
+- Adding explicit cognitive overhead (breadth, directory/extension diversity, balanced edits, language complexity) and raising PR process overheads produce materially higher, more realistic numbers for this repository sample.
+- The run uses banded outputs (min/max) and cycle‑time caps for PRs; increasing `PR_CYCLE_TIME_CAP_RATIO` to 0.8 reduces clipping when wall time is not a limiting factor.
+
+Notes & Next Steps (optional)
+
+- Keep defaults moderate but provide documented presets and env overrides for teams to calibrate per repo.
+- If the conservative profile aligns better with intuition across more repos, consider moving some values into the compiled defaults in a future cycle.

--- a/docs/man/git-activity-report.1
+++ b/docs/man/git-activity-report.1
@@ -4,7 +4,7 @@
 .SH NAME
 git\-activity\-report \- Export Git activity to JSON (simple or sharded)
 .SH SYNOPSIS
-\fBgit\-activity\-report\fR [\fB\-\-repo\fR] [\fB\-\-month\fR] [\fB\-\-for\fR] [\fB\-\-since\fR] [\fB\-\-until\fR] [\fB\-\-simple\fR] [\fB\-\-full\fR] [\fB\-\-include\-merges\fR] [\fB\-\-include\-patch\fR] [\fB\-\-max\-patch\-bytes\fR] [\fB\-\-save\-patches\fR] [\fB\-\-split\-out\fR] [\fB\-\-out\fR] [\fB\-\-github\-prs\fR] [\fB\-\-include\-unmerged\fR] [\fB\-\-tz\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] 
+\fBgit\-activity\-report\fR [\fB\-\-repo\fR] [\fB\-\-month\fR] [\fB\-\-for\fR] [\fB\-\-since\fR] [\fB\-\-until\fR] [\fB\-\-split\-apart\fR] [\fB\-\-detailed\fR] [\fB\-\-estimate\-effort\fR] [\fB\-\-include\-merges\fR] [\fB\-\-include\-patch\fR] [\fB\-\-max\-patch\-bytes\fR] [\fB\-\-save\-patches\fR] [\fB\-\-out\fR] [\fB\-\-github\-prs\fR] [\fB\-\-include\-unmerged\fR] [\fB\-\-tz\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] 
 .SH DESCRIPTION
 Export Git activity to JSON (simple or sharded)
 .SH OPTIONS
@@ -24,11 +24,14 @@ Custom since (Git approxidate ok); must be paired with \-\-until
 \fB\-\-until\fR \fI<UNTIL>\fR
 Custom until (exclusive); must be paired with \-\-since
 .TP
-\fB\-\-simple\fR
-Single JSON output (quick)
+\fB\-\-split\-apart\fR
+Split output into multiple files (per\-commit shards) and include an items index in the report
 .TP
-\fB\-\-full\fR
-Sharded output (per\-commit files + manifest)
+\fB\-\-detailed\fR
+Convenience: turn on all enrichment/detail flags (unmerged, github, patches, etc.)
+.TP
+\fB\-\-estimate\-effort\fR
+Compute effort estimates for commits and PRs (opt\-in)
 .TP
 \fB\-\-include\-merges\fR
 Include merge commits
@@ -42,11 +45,8 @@ Per\-commit patch cap (0 = no limit)
 \fB\-\-save\-patches\fR \fI<SAVE_PATCHES>\fR
 Directory to write .patch files (referenced in JSON)
 .TP
-\fB\-\-split\-out\fR \fI<SPLIT_OUT>\fR
-Base directory for sharded output (full mode). If omitted, auto\-named
-.TP
 \fB\-\-out\fR \fI<OUT>\fR [default: \-]
-File for \-\-simple (default stdout "\-")
+Output location: \- without `\-\-split\-apart` (single report): file path (default stdout "\-") \- with `\-\-split\-apart` or multi\-range runs: base directory (default: auto\-named temp dir)
 .TP
 \fB\-\-github\-prs\fR
 Try to enrich with GitHub PRs (quietly ignored if not available)
@@ -55,11 +55,7 @@ Try to enrich with GitHub PRs (quietly ignored if not available)
 Scan local branches for commits in the window not reachable from HEAD; include separately
 .TP
 \fB\-\-tz\fR \fI<TZ>\fR [default: local]
-Timezone for local ISO timestamps in output (label only)
-.br
-
-.br
-[\fIpossible values: \fRlocal, utc]
+Timezone for local ISO timestamps in output (label only) Timezone for local ISO timestamps in output: "local", "utc", or IANA zone like "America/Chicago"
 .TP
 \fB\-h\fR, \fB\-\-help\fR
 Print help

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -57,6 +57,10 @@ pub struct Cli {
   #[arg(long)]
   pub detailed: bool,
 
+  /// Compute effort estimates for commits and PRs (opt-in)
+  #[arg(long)]
+  pub estimate_effort: bool,
+
   /// Include merge commits
   #[arg(long)]
   pub include_merges: bool,
@@ -116,6 +120,7 @@ pub struct EffectiveConfig {
   pub include_unmerged: bool,
   pub tz: String,
   pub now_override: Option<String>,
+  pub estimate_effort: bool,
 }
 
 pub fn normalize(cli: Cli) -> Result<EffectiveConfig> {
@@ -140,6 +145,7 @@ pub fn normalize(cli: Cli) -> Result<EffectiveConfig> {
   let include_unmerged = cli.include_unmerged || cli.detailed;
   let include_patch = cli.include_patch || cli.detailed;
   let github_prs = cli.github_prs || cli.detailed;
+  let estimate_effort = cli.estimate_effort || cli.detailed;
 
   let repo = util::canonicalize_lossy(&cli.repo);
 
@@ -157,6 +163,7 @@ pub fn normalize(cli: Cli) -> Result<EffectiveConfig> {
     include_unmerged,
     tz: cli.tz.clone(),
     now_override: cli.now_override.clone(),
+    estimate_effort,
   })
 }
 
@@ -174,6 +181,7 @@ mod tests {
       until: None,
       split_apart: false,
       detailed: false,
+      estimate_effort: false,
       include_merges: false,
       include_patch: false,
       max_patch_bytes: 0,
@@ -208,5 +216,6 @@ mod tests {
     assert!(cfg.include_unmerged);
     assert!(cfg.include_patch);
     assert!(cfg.github_prs);
+    assert!(cfg.estimate_effort);
   }
 }

--- a/src/enrich.rs
+++ b/src/enrich.rs
@@ -69,6 +69,11 @@ mod tests {
       patch_clipped: None,
       patch_lines: None,
       body_lines: None,
+      estimated_minutes: None,
+      estimated_minutes_min: None,
+      estimated_minutes_max: None,
+      estimate_confidence: None,
+      estimate_basis: None,
       github: None,
     }
   }

--- a/src/enrichment/effort.rs
+++ b/src/enrichment/effort.rs
@@ -1,0 +1,434 @@
+// === Module Header (agents-tooling) START ===
+// header: Parsed by scripts/check_module_headers.sh for purpose/role presence; keep keys on single-line entries.
+// purpose: Pure helpers to estimate developer effort (minutes) from commit/PR features
+// role: enrichment/estimation
+// outputs: EffortEstimate structs computed from in-memory model objects (no IO)
+// invariants:
+// - Best-effort, explainable, and additive-only (no schema changes here)
+// - Deterministic math; bounded outputs; no panics
+// tie_breakers: contracts > orchestration > correctness > performance > minimal_diffs
+// === Module Header END ===
+
+use crate::model::{Commit, GithubPullRequest};
+
+/// A lightweight, explainable estimate of time spent (in minutes).
+#[derive(Debug, Clone, PartialEq)]
+pub struct EffortEstimate {
+  pub minutes: f64,
+  pub min_minutes: f64,
+  pub max_minutes: f64,
+  pub confidence: f32, // 0.0 .. 1.0
+  pub basis: String,   // short human string: e.g., "files=3 lines=120 lang=rust weight=1.25"
+}
+
+/// Static weights and knobs. Future: expose via CLI/env or calibration file.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct EffortWeights {
+  pub base_commit_min: f64,
+  pub per_file_min: f64,
+  pub per_file_tail_min: f64, // after 20 files
+  pub sqrt_lines_coeff: f64,
+  pub rename_discount: f64,
+  pub heavy_delete_discount: f64,
+  pub test_only_discount: f64,
+  pub mixed_tests_uplift: f64,
+}
+
+impl Default for EffortWeights {
+  fn default() -> Self {
+    Self {
+      base_commit_min: 5.0,
+      per_file_min: 0.75,
+      per_file_tail_min: 0.25,
+      sqrt_lines_coeff: 0.9,
+      rename_discount: 0.7,
+      heavy_delete_discount: 0.8,
+      test_only_discount: 0.9,
+      mixed_tests_uplift: 1.05,
+    }
+  }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct PrEstimateParams {
+  pub review_approved_min: f64,
+  pub review_changes_min: f64,
+  pub review_commented_min: f64,
+  pub files_overhead_per_review_min: f64,
+  pub day_drag_min: f64,
+  pub pr_assembly_min: f64,
+  pub approver_only_min: f64,
+  pub cycle_time_cap_ratio: f64,
+}
+
+impl Default for PrEstimateParams {
+  fn default() -> Self {
+    Self {
+      review_approved_min: 9.0,
+      review_changes_min: 6.0,
+      review_commented_min: 4.0,
+      files_overhead_per_review_min: 0.2,
+      day_drag_min: 7.0,
+      pr_assembly_min: 10.0,
+      approver_only_min: 10.0,
+      cycle_time_cap_ratio: 0.5,
+    }
+  }
+}
+
+/// Return a language weight based on simple file extension heuristics.
+fn language_weight(path: &str) -> f64 {
+  let ext = path.rsplit('.').next().unwrap_or("").to_ascii_lowercase();
+
+  match ext.as_str() {
+    // Higher cognitive load
+    "rs" | "ts" | "go" | "java" | "scala" => 1.25,
+    // Moderate
+    "py" | "js" | "tsx" | "jsx" | "rb" | "kt" => 1.1,
+    // Low
+    "md" | "json" | "yaml" | "yml" | "toml" => 0.8,
+    _ => 1.0,
+  }
+}
+
+/// Identify whether a file path likely belongs to tests.
+fn is_test_path(path: &str) -> bool {
+  let p = path.to_ascii_lowercase();
+  p.contains("/test/")
+    || p.contains("/tests/")
+    || p.ends_with("_test.rs")
+    || p.ends_with("_test.py")
+    || p.ends_with(".spec.ts")
+    || p.ends_with(".spec.js")
+}
+
+/// Clamp a value to [min, max].
+fn clamp(v: f64, lo: f64, hi: f64) -> f64 {
+  v.max(lo).min(hi)
+}
+
+/// Estimate effort for a single commit using file stats and light heuristics.
+pub fn estimate_commit_effort(commit: &Commit) -> EffortEstimate {
+  let weights = EffortWeights::default();
+
+  // Phase 1: trivial guards
+  if commit.parents.len() > 1 {
+    return EffortEstimate {
+      minutes: 0.0,
+      min_minutes: 0.0,
+      max_minutes: 0.0,
+      confidence: 0.5,
+      basis: "merge commit".into(),
+    };
+  }
+
+  // Phase 2: extract features (files/lines/tests/renames)
+  let mut files = 0usize;
+  let mut total_add = 0i64;
+  let mut total_del = 0i64;
+  let mut lang_weight_acc = 0.0f64;
+  let mut renames = 0usize;
+  let mut test_files = 0usize;
+
+  for f in &commit.files {
+    files += 1;
+    total_add += f.additions.unwrap_or(0);
+    total_del += f.deletions.unwrap_or(0);
+
+    let w = language_weight(&f.file);
+    lang_weight_acc += w;
+    if is_test_path(&f.file) {
+      test_files += 1;
+    }
+
+    if f.status.starts_with('R') {
+      renames += 1;
+    }
+  }
+
+  let total_lines = (total_add + total_del).max(0) as f64;
+  let avg_lang_weight = if files > 0 { lang_weight_acc / files as f64 } else { 1.0 };
+  let tests_ratio = if files > 0 {
+    test_files as f64 / files as f64
+  } else {
+    0.0
+  };
+  let deletions_ratio = if total_lines > 0.0 {
+    (total_del as f64 / total_lines).clamp(0.0, 1.0)
+  } else {
+    0.0
+  };
+  let rename_ratio = if files > 0 { renames as f64 / files as f64 } else { 0.0 };
+
+  // Phase 3: base minutes with diminishing returns
+  let mut minutes = weights.base_commit_min;
+
+  if files > 0 {
+    let tail = files.saturating_sub(20) as f64;
+    let head = files.min(20) as f64;
+    minutes += head * weights.per_file_min + tail * weights.per_file_tail_min;
+  }
+
+  minutes += total_lines.sqrt() * weights.sqrt_lines_coeff;
+  minutes *= avg_lang_weight;
+
+  if rename_ratio > 0.5 {
+    minutes *= weights.rename_discount;
+  }
+  if deletions_ratio > 0.7 {
+    minutes *= weights.heavy_delete_discount;
+  }
+
+  if tests_ratio >= 0.8 {
+    minutes *= weights.test_only_discount;
+  } else if tests_ratio > 0.0 {
+    minutes *= weights.mixed_tests_uplift;
+  }
+
+  // Phase 4: finalize
+  let minutes = clamp(minutes, 1.0, 240.0);
+  let min_minutes = clamp(minutes * 0.8, 0.5, 240.0);
+  let max_minutes = clamp(minutes * 1.25, 1.0, 360.0);
+
+  let basis = format!(
+    "files={} lines={} lang_w={:.2} tests={:.0}% renames={:.0}%",
+    files,
+    (total_add + total_del).max(0),
+    avg_lang_weight,
+    tests_ratio * 100.0,
+    rename_ratio * 100.0
+  );
+
+  EffortEstimate {
+    minutes,
+    min_minutes,
+    max_minutes,
+    confidence: 0.55,
+    basis,
+  }
+}
+
+/// Derive review-counts triple (approved, changes, commented) from optional counters on PR.
+fn derive_review_counts(pr: &GithubPullRequest) -> (i64, i64, i64) {
+  let approvals = pr.approval_count.unwrap_or(0);
+  let changes = pr.change_request_count.unwrap_or(0);
+  let total = pr.review_count.unwrap_or(approvals + changes);
+  let commented = (total - approvals - changes).max(0);
+  (approvals, changes, commented)
+}
+
+/// Estimate effort for a single PR using commit estimates and review metadata.
+pub fn estimate_pr_effort(pr: &GithubPullRequest, range_commits: &[Commit]) -> EffortEstimate {
+  let _weights = EffortWeights::default();
+  let params = PrEstimateParams::default();
+
+  // Phase 1: collect commit estimates by matching sha
+  let mut subtotal = 0.0f64;
+  let mut matched = 0usize;
+  let mut files_total = 0usize;
+  use std::collections::BTreeSet;
+  let mut distinct_days: BTreeSet<String> = BTreeSet::new();
+
+  if let Some(pr_commits) = &pr.commits {
+    for pc in pr_commits {
+      if let Some(c) = range_commits.iter().find(|c| c.sha == pc.sha) {
+        let est = estimate_commit_effort(c);
+        subtotal += est.minutes;
+        matched += 1;
+        files_total += c.files.len();
+        let day = c.timestamps.commit_local.chars().take(10).collect::<String>();
+        distinct_days.insert(day);
+      }
+    }
+  }
+
+  // Phase 2: review overheads (approximate)
+  let mut overhead = params.pr_assembly_min; // PR assembly + description
+
+  let (approved, changes, commented) = derive_review_counts(pr);
+  if approved > 0 || changes > 0 || commented > 0 {
+    overhead += approved as f64 * params.review_approved_min;
+    overhead += changes as f64 * params.review_changes_min;
+    overhead += commented as f64 * params.review_commented_min;
+    let total_reviews = (approved + changes + commented) as usize;
+    if total_reviews > 1 {
+      let extra = total_reviews - 1;
+      overhead += (files_total as f64) * params.files_overhead_per_review_min * (extra as f64);
+    }
+  } else if pr.approver.is_some() {
+    overhead += params.approver_only_min;
+  }
+
+  // Multi-day drag: additional context-switching cost per extra day
+  if distinct_days.len() > 1 {
+    overhead += (distinct_days.len() as f64 - 1.0) * params.day_drag_min;
+  }
+
+  // Phase 3: finalize
+  let mut minutes = subtotal + overhead;
+
+  // Cycle-time bounding (if created_at/merged_at available)
+  if let (Some(created), Some(merged)) = (&pr.created_at, &pr.merged_at) {
+    if let (Ok(ct), Ok(mt)) = (
+      chrono::DateTime::parse_from_rfc3339(created),
+      chrono::DateTime::parse_from_rfc3339(merged),
+    ) {
+      if mt > ct {
+        let duration_mins = (mt - ct).num_minutes().max(0) as f64;
+        let cap = duration_mins * params.cycle_time_cap_ratio; // bound to a fraction of wall time
+        if minutes > cap {
+          minutes = cap;
+        }
+      }
+    }
+  }
+
+  let confidence = if matched > 0 { 0.65 } else { 0.45 };
+  let min_minutes = clamp(minutes * 0.85, 1.0, 10000.0);
+  let max_minutes = clamp(minutes * 1.2, 1.0, 10000.0);
+
+  let basis = format!(
+    "commits_matched={} subtotal={:.1} overhead={:.1}",
+    matched, subtotal, overhead
+  );
+
+  EffortEstimate {
+    minutes,
+    min_minutes,
+    max_minutes,
+    confidence,
+    basis,
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  fn mk_commit(files: Vec<(&str, &str, i64, i64)>, parents: usize, date: &str) -> Commit {
+    let mut c = Commit {
+      sha: "s".into(),
+      short_sha: "s".into(),
+      parents: vec![],
+      author: crate::model::Person {
+        name: "A".into(),
+        email: "a@ex".into(),
+        date: "".into(),
+      },
+      committer: crate::model::Person {
+        name: "A".into(),
+        email: "a@ex".into(),
+        date: "".into(),
+      },
+      timestamps: crate::model::Timestamps {
+        author: 0,
+        commit: 0,
+        author_local: date.into(),
+        commit_local: date.into(),
+        timezone: "utc".into(),
+      },
+      subject: "s".into(),
+      body: "".into(),
+      files: vec![],
+      diffstat_text: "".into(),
+      patch_references: crate::model::PatchReferences {
+        embed: false,
+        git_show_cmd: "".into(),
+        local_patch_file: None,
+        github: None,
+      },
+      patch_clipped: None,
+      patch_lines: None,
+      body_lines: None,
+      estimated_minutes: None,
+      estimated_minutes_min: None,
+      estimated_minutes_max: None,
+      estimate_confidence: None,
+      estimate_basis: None,
+      github: None,
+    };
+    c.parents = (0..parents).map(|_| "p".into()).collect();
+    c.files = files
+      .into_iter()
+      .map(|(file, status, add, del)| crate::model::FileEntry {
+        file: file.into(),
+        status: status.into(),
+        old_path: None,
+        additions: Some(add),
+        deletions: Some(del),
+      })
+      .collect();
+    c
+  }
+
+  #[test]
+  fn commit_basic_weights() {
+    let c = mk_commit(vec![("src/lib.rs", "M", 100, 20)], 1, "2025-09-01T00:00:00Z");
+    let e = estimate_commit_effort(&c);
+    assert!(e.minutes > 5.0);
+    assert!(e.max_minutes > e.minutes);
+    assert!(e.min_minutes < e.minutes);
+  }
+
+  #[test]
+  fn commit_rename_discount_applies() {
+    let c1 = mk_commit(vec![("a.txt", "M", 50, 0)], 1, "2025-09-01T00:00:00Z");
+    let c2 = mk_commit(vec![("b.txt", "R100", 50, 0)], 1, "2025-09-01T00:00:00Z");
+    let e1 = estimate_commit_effort(&c1);
+    let e2 = estimate_commit_effort(&c2);
+    assert!(e2.minutes < e1.minutes);
+  }
+
+  #[test]
+  fn pr_estimation_uses_commits_reviews_and_days() {
+    let c1 = mk_commit(vec![("src/lib.rs", "M", 10, 10)], 1, "2025-09-01T00:00:00Z");
+    let mut c2 = mk_commit(vec![("src/main.rs", "M", 10, 10)], 1, "2025-09-02T00:00:00Z");
+    c2.sha = "b".into();
+    let mut c1b = c1.clone();
+    c1b.sha = "a".into();
+    let range = vec![c1b.clone(), c2.clone()];
+    let pr = GithubPullRequest {
+      number: 1,
+      title: "t".into(),
+      state: "closed".into(),
+      body_lines: None,
+      created_at: Some("2025-09-01T00:00:00Z".into()),
+      merged_at: Some("2025-09-03T00:00:00Z".into()),
+      closed_at: None,
+      html_url: "".into(),
+      diff_url: None,
+      patch_url: None,
+      submitter: None,
+      approver: None,
+      reviewers: None,
+      head: None,
+      base: None,
+      commits: Some(vec![
+        crate::model::PullRequestCommit {
+          sha: c1b.sha.clone(),
+          short_sha: c1b.short_sha.clone(),
+          subject: c1b.subject.clone(),
+        },
+        crate::model::PullRequestCommit {
+          sha: c2.sha.clone(),
+          short_sha: c2.short_sha.clone(),
+          subject: c2.subject.clone(),
+        },
+      ]),
+      review_count: Some(3),
+      approval_count: Some(2),
+      change_request_count: Some(1),
+      time_to_first_review_seconds: None,
+      time_to_merge_seconds: None,
+      estimated_minutes: None,
+      estimated_minutes_min: None,
+      estimated_minutes_max: None,
+      estimate_confidence: None,
+      estimate_basis: None,
+    };
+    let e = estimate_pr_effort(&pr, &range);
+    assert!(e.minutes > 0.0);
+    assert!(e.max_minutes >= e.minutes);
+    assert!(e.min_minutes <= e.minutes);
+  }
+}

--- a/src/enrichment/github_api.rs
+++ b/src/enrichment/github_api.rs
@@ -539,6 +539,11 @@ pub fn try_fetch_prs_for_commit(repo: &str, sha: &str) -> anyhow::Result<Vec<Git
       change_request_count,
       time_to_first_review_seconds,
       time_to_merge_seconds,
+      estimated_minutes: None,
+      estimated_minutes_min: None,
+      estimated_minutes_max: None,
+      estimate_confidence: None,
+      estimate_basis: None,
     };
     out.push(item);
   }

--- a/src/enrichment/github_pull_requests.rs
+++ b/src/enrichment/github_pull_requests.rs
@@ -211,6 +211,11 @@ pub fn enrich_with_github_prs_with_api(commit: &mut Commit, repo: &str, api: &dy
       change_request_count: None,
       time_to_first_review_seconds: None,
       time_to_merge_seconds: None,
+      estimated_minutes: None,
+      estimated_minutes_min: None,
+      estimated_minutes_max: None,
+      estimate_confidence: None,
+      estimate_basis: None,
     };
 
     out.push(item);
@@ -381,6 +386,11 @@ fn build_aggregated_pr(
     change_request_count,
     time_to_first_review_seconds,
     time_to_merge_seconds,
+    estimated_minutes: None,
+    estimated_minutes_min: None,
+    estimated_minutes_max: None,
+    estimate_confidence: None,
+    estimate_basis: None,
   }
 }
 
@@ -425,6 +435,11 @@ mod tests {
       patch_clipped: None,
       patch_lines: None,
       body_lines: None,
+      estimated_minutes: None,
+      estimated_minutes_min: None,
+      estimated_minutes_max: None,
+      estimate_confidence: None,
+      estimate_basis: None,
       github: None,
     };
     c.github = Some(CommitGithub {
@@ -450,6 +465,11 @@ mod tests {
         change_request_count: None,
         time_to_first_review_seconds: None,
         time_to_merge_seconds: None,
+        estimated_minutes: None,
+        estimated_minutes_min: None,
+        estimated_minutes_max: None,
+        estimate_confidence: None,
+        estimate_basis: None,
       }],
     });
     c

--- a/src/enrichment/mod.rs
+++ b/src/enrichment/mod.rs
@@ -7,5 +7,6 @@
 // tie_breakers: contracts > orchestration > correctness > performance > minimal_diffs
 // === Module Header END ===
 
+pub mod effort;
 pub mod github_api;
 pub mod github_pull_requests;

--- a/src/model.rs
+++ b/src/model.rs
@@ -76,6 +76,17 @@ pub struct Commit {
   pub patch_lines: Option<Vec<String>>,
   #[serde(skip_serializing_if = "Option::is_none")]
   pub body_lines: Option<Vec<String>>,
+  // Optional effort estimation (best-effort, minutes)
+  #[serde(skip_serializing_if = "Option::is_none")]
+  pub estimated_minutes: Option<f64>,
+  #[serde(skip_serializing_if = "Option::is_none")]
+  pub estimated_minutes_min: Option<f64>,
+  #[serde(skip_serializing_if = "Option::is_none")]
+  pub estimated_minutes_max: Option<f64>,
+  #[serde(skip_serializing_if = "Option::is_none")]
+  pub estimate_confidence: Option<f64>,
+  #[serde(skip_serializing_if = "Option::is_none")]
+  pub estimate_basis: Option<String>,
   #[serde(skip_serializing_if = "Option::is_none")]
   pub github: Option<CommitGithub>,
 }
@@ -176,6 +187,17 @@ pub struct GithubPullRequest {
   pub time_to_first_review_seconds: Option<i64>,
   #[serde(skip_serializing_if = "Option::is_none")]
   pub time_to_merge_seconds: Option<i64>,
+  // Optional effort estimation (best-effort, minutes)
+  #[serde(skip_serializing_if = "Option::is_none")]
+  pub estimated_minutes: Option<f64>,
+  #[serde(skip_serializing_if = "Option::is_none")]
+  pub estimated_minutes_min: Option<f64>,
+  #[serde(skip_serializing_if = "Option::is_none")]
+  pub estimated_minutes_max: Option<f64>,
+  #[serde(skip_serializing_if = "Option::is_none")]
+  pub estimate_confidence: Option<f64>,
+  #[serde(skip_serializing_if = "Option::is_none")]
+  pub estimate_basis: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]

--- a/src/range_processor.rs
+++ b/src/range_processor.rs
@@ -259,6 +259,7 @@ mod tests {
       include_unmerged: false,
       tz: "utc".into(),
       now_override: None,
+      estimate_effort: false,
     }
   }
 

--- a/tests/integration/effort_estimation.rs
+++ b/tests/integration/effort_estimation.rs
@@ -1,0 +1,84 @@
+use assert_cmd::Command;
+use serde_json::json;
+use test_support;
+
+#[test]
+fn estimates_present_when_flag_enabled() {
+  test_support::init_tracing();
+  test_support::init_insta();
+  let _env = test_support::with_env(&[("TZ", "UTC")]);
+
+  // Provide env-backed API payloads to ensure a PR is attached
+  std::env::set_var(
+    "GAR_TEST_PR_JSON",
+    json!([{ "html_url": "https://github.com/openai/example/pull/1", "number": 1, "title": "T", "state": "closed" }]).to_string(),
+  );
+  std::env::set_var(
+    "GAR_TEST_PULL_DETAILS_JSON",
+    json!({
+      "html_url": "https://github.com/openai/example/pull/1",
+      "number": 1,
+      "title": "T",
+      "state": "closed",
+      "user": {"login": "octo"},
+      "author_association": "MEMBER",
+      "created_at": "2024-01-01T00:00:00Z",
+      "merged_at": "2024-01-01T02:00:00Z",
+      "closed_at": "2024-01-01T02:00:00Z",
+      "head": {"ref": "f"},
+      "base": {"ref": "m"}
+    })
+    .to_string(),
+  );
+  std::env::set_var(
+    "GAR_TEST_PR_REVIEWS_JSON",
+    json!([
+      {"state": "COMMENTED", "user": {"login": "alice"}, "author_association": "CONTRIBUTOR", "submitted_at": "2024-01-01T01:00:00Z"},
+      {"state": "APPROVED", "user": {"login": "bob"}, "author_association": "MEMBER", "submitted_at": "2024-01-01T01:30:00Z"}
+    ])
+    .to_string(),
+  );
+
+  let repo = test_support::fixture_repo();
+  let repo_path = repo.to_str().unwrap();
+
+  let out = Command::cargo_bin("git-activity-report")
+    .unwrap()
+    .args([
+      "--since",
+      "2025-08-01",
+      "--until",
+      "2025-09-01",
+      "--repo",
+      repo_path,
+      "--tz",
+      "utc",
+      "--now-override",
+      "2025-08-15T12:00:00",
+      "--estimate-effort",
+      "--github-prs",
+    ])
+    .output()
+    .unwrap();
+  assert!(out.status.success(), "cli run failed: {}", String::from_utf8_lossy(&out.stderr));
+
+  let v: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+  let commits = v["commits"].as_array().expect("commits array");
+  // At least one commit has estimated_minutes
+  assert!(commits.iter().any(|c| c.get("estimated_minutes").and_then(|x| x.as_f64()).is_some()));
+
+  // And at least one PR on any commit has estimated_minutes when PRs are present
+  let any_pr_est = commits.iter().flat_map(|c| {
+    c.get("github")
+      .and_then(|g| g.get("pull_requests"))
+      .and_then(|a| a.as_array().cloned())
+      .unwrap_or_default()
+  }).any(|pr| pr.get("estimated_minutes").and_then(|x| x.as_f64()).is_some());
+  assert!(any_pr_est, "expected some PR estimation present");
+
+  // Clean env
+  std::env::remove_var("GAR_TEST_PR_JSON");
+  std::env::remove_var("GAR_TEST_PULL_DETAILS_JSON");
+  std::env::remove_var("GAR_TEST_PR_REVIEWS_JSON");
+}
+


### PR DESCRIPTION
# Cycle 0012 — plan: integrate time estimation enrichment (feat/add-time-estimation-enrichment) (2025-09-12T21-43-46)


Use this template before editing code. Keep it short and decisive. Save a copy as `$GITROOT/.agents/cycles/<idx>.<short-desc>.<timestamp>.md` to log each cycle.

1) Summary

- Problem/intent:
  - Incorporate the time‑estimation enrichment from `feat/add-time-estimation-enrichment` safely on top of `main`. Due to heavy divergence (model/cli/render) and known merge conflicts, prefer a clean re‑implementation that preserves current contracts and layout rules.

- Deliverables (code/docs/tests):
  - New pure module: `src/enrichment/effort.rs` (commit/PR estimators).
  - CLI flag: `--estimate-effort` (opt‑in; implied by `--detailed`).
  - Additive optional fields on `Commit` and `GithubPullRequest`: `estimated_minutes`, `estimated_minutes_min`, `estimated_minutes_max`, `estimate_confidence`, `estimate_basis`.
  - Wiring in `commit.rs` (commit estimate) and post‑loop PR pass.
  - Unit + integration tests; schema updates to allow optional fields; docs/man refresh.

- Scope (modules/files/areas):
  - Add: `src/enrichment/effort.rs` (+ tests).
  - Touch: `src/model.rs`, `src/cli.rs`, `src/commit.rs`, `src/enrichment/mod.rs`, and minimal `src/render.rs` for PR pass; `tests/schemas/*`, `tests/integration/*`, `README.md`, `docs/man`.

2) Context & Constraints

- Domain context (what system does):
  - Export Git activity to JSON with optional enrichment; estimations are explainable best‑effort hints.

- Primary consumers (humans/services):
  - Report‑writer agents and humans consuming JSON/Markdown outputs.

- External contracts (APIs/schemas/CLIs):
  - JSON Schemas remain backward‑compatible; new fields are additive/optional. CLI coherence with `--detailed` maintained.

3) State & Invariants

- State variables (k: description):
  - `estimate_enabled` (bool), `weights`/`params` (in‑mem defaults).

- Derived state (computed once):
  - `range_commits` vector for PR estimates across the window.

- Invariants (pre/post, must always hold):
  - Only additive schema changes; no breaking renames.
  - Estimation is pure (no IO/network), deterministic, panic‑free.
  - Author enforced spacing/layout; one blank between compute/IO/push.

4) Inputs → Outputs (Contracts)

- Inputs (flags, env, APIs, files):
  - Flags: `--estimate-effort` (opt‑in). Hidden tuning knobs deferred.
  - Env/APIs: none new; reuse existing GitHub enrichment data.

- Outputs (files, API responses, console):
  - Commit/PR objects gain optional estimation fields when enabled.

- Naming/shape contracts (stable filenames/paths; schema versions; pointer shapes):
  - Field names: `estimated_minutes`, `estimated_minutes_min`, `estimated_minutes_max`, `estimate_confidence`, `estimate_basis` (minutes as unit).

5) Orchestration Plan (Phases)

- Phase 1 — Normalize/build inputs:
  - Parse CLI → `estimate_enabled` in config.

- Phase 2 — Resolve/derive:
  - Build `ReportParams` carrying `estimate_enabled`.

- Phase 3 — Process units (loop): generate → save/persist → index
  - Build `Commit`; if enabled, attach commit estimate.
  - If GitHub enrichment present and enabled, compute PR estimates after loop using range commits.

- Finalize — aggregate/manifest → emit/return
  - No filename/manifest changes; totals deferred to future cycle.

6) Module/Boundary Plan

- Resolution/parser module(s): `src/cli.rs`.
- Processing/orchestrator module(s): `src/commit.rs` (commit estimate), `src/render.rs` (PR pass).
- Assembly/rendering module(s): unchanged.
- Persistence/manifest module(s): unchanged.
- Enrichment/integration module(s): `src/enrichment/effort.rs`; export in `src/enrichment/mod.rs`.
- Utilities/helpers: none new.

7) Side Effects & IO

- Filesystem (paths, write strategy): none new.
- Network/API calls (best-effort vs. required): none; uses in‑memory data.
- Subprocess/system calls: none.
- Concurrency decisions: unchanged; estimators are cheap.

8) Testing & Validation

- Unit tests (pure helpers): estimator math (rename/test discounts; reviews; multi‑day drag; cycle‑time cap).
- Contract tests (schemas/pointers/naming): add optional fields to schemas.
- Integration tests (end-to-end scenarios): CLI with `--estimate-effort --detailed` over fixture; assert fields exist and sane.
- Manual checks (smoke/paths/outputs): `just run-simple`, `just man`.

9) Risks & Trade-offs

- Purity vs. performance: pure helpers; negligible overhead.
- Stability vs. ergonomics: minimal CLI surface; defer knobs.
- Backward compatibility/migration: additive, flag‑gated; schemas updated.

10) Tie-Breakers (apply in this order)

1. Contract stability (filenames/schemas/protocols)
2. Orchestration simplicity (single loop, explicit state)
3. Correctness/testability (pure helpers, invariants)
4. Performance (avoid duplicate heavy work)
5. Minimal diff/readability

11) Observability & Rollback

- Logs/metrics/counters: none; `estimate_basis` string offers explainability.
- Pointer/evidence to outputs: fields appear only when flag set.
- Rollback plan: revert wiring commit or simply stop populating fields; helpers remain for later use.

12) Cycle Metadata

- Cycle id:
- Short description:
- Timestamp (start/end):
- Links (PR/issues):


---
Repo Overlay (autogenerated skeleton)

States (define enumerated program states here):
- [fill: e.g., single, multi, write, preview, split, monolithic]

Modules → Roles (from file headers):
- src/commit.rs: commit construction/enrichment — Construct per-commit objects; enrich with optional PR links; embed or save patches as configured
- src/gitio.rs: git/io-helpers — Provide thin, robust wrappers around `git` CLI to retrieve commit metadata, diffs, stats, and branch info for report generation
- src/util.rs: utilities/helpers — Utilities for paths, time formatting, spacing-safe helpers, and man page rendering
- src/render.rs: assembly/render — Assemble per-range reports; when split_apart, write commit shards and per-range report, returning a pointer
- src/enrich.rs: enrichment/coordinator — Coordinator to apply configured enrichments; keeps orchestration separate from enrichment implementations
- src/manifest.rs: persistence/manifest — Build and write overall manifest for multi-range runs
- src/main.rs: entrypoint/orchestrator — Entrypoint orchestrator; normalize → resolve ranges → process ranges; print final JSON or pointer
- src/range_windows.rs: resolution/parser — Resolve time windows into labeled ranges; parse "now" overrides; helpers for natural language buckets
- src/range_processor.rs: processing/orchestrator — Orchestrate per-range processing: generate report JSON and save artifacts; assemble overall manifest for multi-range runs
- src/model.rs: model/types — Define the JSON model (commits, ranges, manifests, GitHub PRs) shared by rendering and enrichment
- src/cli.rs: cli/normalization — Parse CLI flags and produce an EffectiveConfig with consistent defaults and implied flags
- src/ext/mod.rs: module/aggregation — Group extension traits and helpers for third-party crates and std types under a single `ext` namespace
- src/ext/serde_json.rs: extension/serde_json — Provide ergonomic nested JSON fetching via dotted paths and safe typed extraction for serde_json::Value
- src/enrichment/github_api.rs: enrichment/github-api — Isolated GitHub API helpers used by enrichment (token discovery, REST calls)
- src/enrichment/github_pull_requests.rs: enrichment/integration — Best-effort enrichment adding GitHub PR links and PR list to a commit
- src/enrichment/mod.rs: enrichment/namespace — Namespace for enrichment features (GitHub PRs, etc.)

Module Outputs (from file headers):
- src/commit.rs → Commit structs with files/diffstat/patch_ref; optional patch text and saved patch files
- src/gitio.rs → Parsed commit meta, numstat/name-status, shortstat, patch text; branch names and ahead/behind/merged signals
- src/util.rs → Canonicalized paths, formatted timestamps, directories ensured, man page text
- src/render.rs → SimpleReport JSON (non-split) or pointer {dir, file} (split)
- src/enrich.rs → Mutates Commit (per-commit enrichments) and returns optional aggregated enrichments for reports
- src/manifest.rs → manifest.json file written under base_dir
- src/main.rs → Either full JSON to stdout, or a pointer {dir,file}/{dir,manifest} to stdout; files on disk when split/multi
- src/range_windows.rs → Vec<LabeledRange> (chronological earliest→latest); parsed DateTime for now when requested
- src/range_processor.rs → Files on disk (reports, shards), optional manifest.json; stdout pointer or JSON per state
- src/model.rs → Serializable structs with stable field names and optional enrichment fields
- src/cli.rs → EffectiveConfig with normalized paths and flags; multi_windows is initialized false (set later)
- src/ext/mod.rs → Re-exported submodules providing utility traits and helpers (e.g., JsonFetch)
- src/ext/serde_json.rs → JsonFetch trait and JsonFetched wrapper for typed extraction with defaults
- src/enrichment/github_api.rs → JSON values and typed commit snapshots for PRs
- src/enrichment/github_pull_requests.rs → Mutated commit.patch_ref (diff/patch URLs) and commit.github_prs
- src/enrichment/mod.rs → Public submodules implementing specific enrichments

Module Invariants (from file headers):
- src/commit.rs
  - clip_patch preserves UTF-8 boundaries; patch_clipped is accurate
  - body_lines derived when body is non-empty
  - enrichment is best-effort; absence of PRs leaves fields None
- src/util.rs
  - prepare_out_dir returns an existing directory (either provided or temp timestamped)
  - clip_patch never splits UTF-8; indicates clipping accurately
  - format_shard_name pattern is stable and locale-independent
- src/render.rs
  - run_simple returns fully in-memory report consistent with schema
  - run_report returns pointer JSON when split; otherwise full report JSON; file names are stable
  - shard filenames follow YYYY.MM.DD-HH.MM-<shortsha>.json
- src/manifest.rs
  - manifest contains ranges[] in chronological order of entries provided
  - file paths in entries are relative to base_dir and point to report-<label>.json
  - generated_at is serialized in %Y-%m-%dT%H:%M:%S (local)
- src/main.rs
  - when cfg.multi_windows == true, an overall manifest.json is written and a pointer with {dir, manifest} is printed
  - when cfg.split_apart == true and cfg.multi_windows == false, a pointer {dir, file} is printed for the range report
  - when cfg.split_apart == false and cfg.multi_windows == false, a full JSON report is printed to stdout or written to --out
- src/range_windows.rs
  - resolve_ranges returns at least one range; ForPhrase buckets are ordered earliest→latest
  - month_bounds yields [start_of_month, start_of_next_month]
  - parse_now accepts RFC3339 or naive %Y-%m-%dT%H:%M:%S and never panics
- src/range_processor.rs
  - base_dir is prepared when split_apart || multi_windows
  - per-range report file name is report-<label>.json when written to disk
  - multi_windows ⇒ manifest.json exists and pointer {dir, manifest} printed
  - single split ⇒ pointer {dir, file} printed; single non-split ⇒ JSON printed or written to --out
- src/cli.rs
  - exactly one window selection is provided: --month | --for | (--since & --until)
  - --detailed implies include_unmerged/include_patch/github_prs
  - out semantics: file path when single non-split; directory when split or multi
- src/enrichment/github_api.rs
  - Never panic; return None/empty on failures (best-effort enrichment)
  - Token discovery prefers GITHUB_TOKEN, then `gh auth token`
  - Origin parser only recognizes GitHub remotes (https or ssh)
- src/enrichment/github_pull_requests.rs
  - On success, preserves existing commit fields; sets URLs if present in first PR; attaches PR list
  - On failure, commit remains valid; fields untouched

Acceptance (checklist to adapt):
- [ ] Program state derived once and stored centrally
- [ ] Outputs mapped to enumerated states
- [ ] Names/shapes stable and test-covered
- [ ] Orchestrator phases clear; IO at edges
- [ ] Invariants defined and asserted
- [ ] Errors include what/where
- [ ] Observability: pointers/ids/paths logged/printed

Cycle Metadata (prefilled)

- Cycle id: 0012
- Short description: plan: integrate time estimation enrichment (feat/add-time-estimation-enrichment)
- Timestamp: 2025-09-12T21-43-46
- File: .agents/cycles/0012.plan-integrate-time-estimation-enrichment-feat-add-time-estimation-enrichment.2025-09-12T21-43-46.md
