### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/imajes/git-activity-report/security/code-scanning/4](https://github.com/imajes/git-activity-report/security/code-scanning/4)

To resolve the issue, add a `permissions:` block specifying the least privileges required for the workflow. Since the provided steps don't interact with repository contents in a write capacity, adding `contents: read` suffices for the majority of CI workflows. You can place this block either at the root of the workflow file (recommended, as it applies to all jobs unless overridden) or within each job as needed. Edit `.github/workflows/ci.yml` and add the block directly below the workflow name at the top of the file. No additional libraries or setup is needed—just this YAML change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
