### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/agent-cycle-check.yml
+++ b/.github/workflows/agent-cycle-check.yml
@@ -5,6 +5,8 @@ on:
   push:
     branches: [ main, master ]
 
+permissions:
+  contents: read
 jobs:
   checks:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/imajes/git-activity-report/security/code-scanning/3](https://github.com/imajes/git-activity-report/security/code-scanning/3)

To fix this problem, an explicit `permissions` block should be added to the workflow to minimize the privileges of the GITHUB_TOKEN used in the job. Since the steps only need to check out code and run scripts, the minimal required permission is `contents: read`. According to GitHub best practices, it's recommended to place this permissions block at the root of the workflow YAML file (before the `jobs:` block), which applies to all jobs unless overridden. No imports or additional definitions are required; simply add:

```yaml
permissions:
  contents: read
```

between the `on:` block and the `jobs:` block in `.github/workflows/agent-cycle-check.yml`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
