### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,6 @@
 name: Release
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/imajes/git-activity-report/security/code-scanning/1](https://github.com/imajes/git-activity-report/security/code-scanning/1)

To fix the problem, the workflow should explicitly set the `permissions` key either at the workflow root (which applies to all jobs unless overridden) or specifically in the `build` job. Since the `release` job already sets its required permissions (`contents: write`), the best fix is to add a minimal permissions block to the top-level workflow, setting least privilege default (`contents: read`). This guarantees the `build` job runs with only read access to contents, reducing the risk of unintended capability. No additional imports or definitions are needed; only a YAML block needs to be added at the top level.

Update required: Insert a `permissions: contents: read` block after the workflow name (line 2), so it drops into place before `on:`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
